### PR TITLE
fix: preferred source combobox shows always @multiplex

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -6,8 +6,11 @@
         <entry name="panelIcon" type="string">
             <default>view-media-track</default>
         </entry>
-        <entry name="sourceName" type="string">
-            <default>@multiplex</default>
+        <entry name="sourceIndex" type="string">
+            <default>0</default>
+        </entry>
+        <entry name="sources" type="StringList">
+            <default>@multiplex,spotify,vlc,plasma-browser-integration</default>
         </entry>
         <entry name="maxSongWidthInPanel" type="string">
             <default>200</default>

--- a/src/contents/ui/ConfigGeneral.qml
+++ b/src/contents/ui/ConfigGeneral.qml
@@ -10,8 +10,9 @@ Item {
 
     property alias cfg_panelIcon: panelIcon.value
     property alias cfg_commandsInPanel: commandsInPanel.checked
-    property alias cfg_sourceName: sourceName.currentValue
     property alias cfg_maxSongWidthInPanel: maxSongWidthInPanel.value
+    property alias cfg_sourceIndex: sourceComboBox.currentIndex
+    property alias cfg_sources: sourceComboBox.model
 
     Kirigami.FormLayout {
         anchors.left: parent.left
@@ -23,19 +24,14 @@ Item {
         }
 
         ComboBox {
-            id: sourceName
+            id: sourceComboBox
             editable: true
-            model: ListModel {
-                id: model
-                ListElement { text: "@multiplex" }
-                ListElement { text: "spotify" }
-                ListElement { text: "vlc" }
-                ListElement { text: "plasma-browser-integration" }
-            }
-            onAccepted: {
+
+            onAccepted: () => {
                 if (find(editText) === -1)
-                    model.append({text: editText})
+                    model = [...model, editText]
             }
+
             Kirigami.FormData.label: i18n("Preferred MPRIS2 source:")
         }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,7 @@ Item {
 
     PlayerDataSource {
         id: player
-        sourceName: plasmoid.configuration.sourceName
+        sourceName: plasmoid.configuration.sources[plasmoid.configuration.sourceIndex]
     }
 
     visible: player.ready


### PR DESCRIPTION
The preferred source combobox shows `@multiplex` also when the saved preferred source is an other.

Fix #3