### PR TITLE
fix: sourceName comparison in PlayerDatasource lifecycle functions

### DIFF
--- a/src/contents/ui/PlayerDataSource.qml
+++ b/src/contents/ui/PlayerDataSource.qml
@@ -46,13 +46,13 @@ PlasmaCore.DataSource {
     connectedSources: []
 
     Component.onCompleted: () => {
-        if (this.sources.find(s => this.sourceName)) {
+        if (this.sources.find(s => s === this.sourceName)) {
             this.connectSource(this.sourceName)
         }
     }
 
     onSourceNameChanged: () => {
-        if (this.sources.find(s => this.sourceName)) {
+        if (this.sources.find(s => s === this.sourceName)) {
             this.connectSource(this.sourceName)
         }
     }


### PR DESCRIPTION
This caused the datasource to connect to a source even when it wasn't available. As a result, when the source did become available, the connectSource function had no effect.

Fix #18