### PR TITLE
feat: add new scrolling options for song text overflow

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -24,5 +24,8 @@
         <entry name="textScrollingSpeed" type="Int">
             <default>3</default>
         </entry>
+        <entry name="textScrollingBehaviour" type="int">
+            <default>0</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/ConfigGeneral.qml
+++ b/src/contents/ui/ConfigGeneral.qml
@@ -2,6 +2,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.5
 import org.kde.kirigami 2.4 as Kirigami
 import org.kde.plasma.components 3.0 as PlasmaComponents3
+import QtQuick.Layouts 1.15
 
 Item {
     id: page
@@ -15,6 +16,7 @@ Item {
     property alias cfg_sourceIndex: sourceComboBox.currentIndex
     property alias cfg_sources: sourceComboBox.model
     property alias cfg_textScrollingSpeed: textScrollingSpeed.value
+    property alias cfg_textScrollingBehaviour: scrollingBehaviourRadio.value
 
     Kirigami.FormLayout {
         anchors.left: parent.left
@@ -70,6 +72,40 @@ Item {
             to: 10
             stepSize: 1
             Kirigami.FormData.label: i18n("Text scrolling speed:")
+        }
+
+        ColumnLayout {
+            id: scrollingBehaviourRadio
+            property int value: ScrollingText.OverflowBehaviour.AlwaysScroll
+
+            Kirigami.FormData.label: i18n("Scrolling behaviour when song text overflows:")
+            RadioButton {
+                text: i18n("Always scroll")
+                checked: scrollingBehaviourRadio.value == ScrollingText.OverflowBehaviour.AlwaysScroll
+                onCheckedChanged: () => {
+                    if (checked) {
+                        scrollingBehaviourRadio.value = ScrollingText.OverflowBehaviour.AlwaysScroll
+                    }
+                }
+            }
+            RadioButton {
+                text: i18n("Scroll only on mouse over")
+                checked: scrollingBehaviourRadio.value == ScrollingText.OverflowBehaviour.ScrollOnMouseOver
+                onCheckedChanged: () => {
+                    if (checked) {
+                        scrollingBehaviourRadio.value = ScrollingText.OverflowBehaviour.ScrollOnMouseOver
+                    }
+                }
+            }
+            RadioButton {
+                text: i18n("Always scroll except on mouse over")
+                checked: scrollingBehaviourRadio.value == ScrollingText.OverflowBehaviour.StopScrollOnMouseOver
+                onCheckedChanged: () => {
+                    if (checked) {
+                        scrollingBehaviourRadio.value = ScrollingText.OverflowBehaviour.StopScrollOnMouseOver
+                    }
+                }
+            }
         }
 
         Kirigami.Separator {

--- a/src/contents/ui/ScrollingText.qml
+++ b/src/contents/ui/ScrollingText.qml
@@ -6,6 +6,14 @@ import org.kde.plasma.components 3.0 as PlasmaComponents3
 Item {
     id: root
 
+    enum OverflowBehaviour {
+        AlwaysScroll,
+        ScrollOnMouseOver,
+        StopScrollOnMouseOver
+    }
+
+    property int overflowBehaviour: ScrollingText.OverflowBehaviour.AlwaysScroll
+
     property string text: ""
     readonly property string spacing: "     "
     readonly property string textAndSpacing: text + spacing
@@ -15,6 +23,16 @@ Item {
     property int speed: 5;
     readonly property int duration: (25 * (11 - speed) + 25)* textAndSpacing.length;
 
+    readonly property bool pauseScrolling: {
+        if (overflowBehaviour === ScrollingText.OverflowBehaviour.AlwaysScroll) {
+            return false;
+        } else if (overflowBehaviour === ScrollingText.OverflowBehaviour.ScrollOnMouseOver) {
+            return !mouse.hovered;
+        } else if (overflowBehaviour === ScrollingText.OverflowBehaviour.StopScrollOnMouseOver) {
+            return mouse.hovered;
+        }
+    }
+
     property alias font: label.font
 
     width: overflow ? maxWidth : textMetrics.width + 10
@@ -23,6 +41,11 @@ Item {
     Layout.preferredHeight: label.implicitHeight
     Layout.preferredWidth: width
     Layout.alignment: Qt.AlignHCenter
+
+    HoverHandler {
+        id: mouse
+        acceptedDevices: PointerDevice.Mouse
+    }
 
     TextMetrics {
         id: textMetrics
@@ -36,6 +59,7 @@ Item {
 
         NumberAnimation on x {
             running: root.overflow
+            paused: root.pauseScrolling
             from: 0
             to: -label.implicitWidth
             duration: root.duration
@@ -45,6 +69,9 @@ Item {
                 label.x = 0;
                 if (running) {
                     restart()
+                }
+                if (root.pauseScrolling) {
+                    pause()
                 }
             }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -45,6 +45,7 @@ Item {
             }
 
             ScrollingText {
+                overflowBehaviour: plasmoid.configuration.textScrollingBehaviour
                 speed: plasmoid.configuration.textScrollingSpeed
                 maxWidth: plasmoid.configuration.maxSongWidthInPanel * units.devicePixelRatio
                 text: [player.artists.join(", "), player.title].filter((x) => x).join(" - ")


### PR DESCRIPTION
When song text overflows the max width:
- Always scroll (default, the only one available until now)
- Scroll only when the mouse is over the text.
- Always scroll except when the mouse is over the text.

Fix https://github.com/ccatterina/plasmusic-toolbar/issues/26, https://github.com/ccatterina/plasmusic-toolbar/issues/27