### PR TITLE
fix: currentPlayer existance check

### DIFF
--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -18,7 +18,7 @@ QtObject {
     property string sourceName: "any"
 
     readonly property bool ready: {
-        if (mpris2Model.currentPlayer === undefined) {
+        if (!mpris2Model.currentPlayer) {
             return false
         }
         return mpris2Model.currentPlayer.desktopEntry === sourceName || sourceName === "any";


### PR DESCRIPTION
The existance of mprisModel.currentPlayer was checked comparing it to undefined but currentPlayer can be also null.