### PR TITLE
fix: Player sources handling improvements

### DIFF
--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -6,12 +6,29 @@ QtObject {
     id: root
 
     property var mpris2Model: Mpris.Mpris2Model {
-        onRowsInserted: (_, rowIndex) => {
-            const CONTAINER_ROLE = Qt.UserRole + 1
-            const player = this.data(this.index(rowIndex, 0), CONTAINER_ROLE)
-            if (player.desktopEntry === root.sourceName) {
-                this.currentIndex = rowIndex;
+        readonly property string sourceName: root.sourceName
+        function chooseCurrentPlayer() {
+            if (sourceName === "any") {
+                currentIndex = 0
+                console.debug("setting current source to multiplex");
+                return
             }
+
+            const CONTAINER_ROLE = Qt.UserRole + 1
+            for (let i = 1; i < rowCount(); i++) {
+                const player = data(index(i, 0), CONTAINER_ROLE)
+                if (player.desktopEntry === sourceName) {
+                    currentIndex = i
+                    console.debug(`setting current source to ${player.desktopEntry} (index ${i})`);
+                    return;
+                }
+            }
+        }
+        onRowsInserted: {
+            chooseCurrentPlayer()
+        }
+        onSourceNameChanged: {
+            chooseCurrentPlayer()
         }
     }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -8,11 +8,15 @@ import org.kde.plasma.private.mpris as Mpris
 
 PlasmoidItem {
     id: widget
-    Plasmoid.status: player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+    Plasmoid.status: PlasmaCore.Types.HiddenStatus
 
     Player {
         id: player
         sourceName: plasmoid.configuration.sources[plasmoid.configuration.sourceIndex]
+        onReadyChanged: {
+          Plasmoid.status = player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+          console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
     }
 
     compactRepresentation: Item {


### PR DESCRIPTION
- Search and set the current player also when the preferred source name changes and not only when a new source is added.
- Search among all the available sources to choose the player to set as the current one.
- Set Plasmoid.status on `player.onReadyChanged` event. Apparently calculating Plasmoid.status using `player.ready` variable not always works.
- Add debug log on events like current player change or player readyness change.

Fix #60 