### PR TITLE
fix: widget visibile when there is no active player

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -8,11 +8,16 @@ import org.kde.plasma.private.mpris as Mpris
 
 PlasmoidItem {
     id: widget
-    Plasmoid.status: player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+
+    Plasmoid.status: PlasmaCore.Types.HiddenStatus
 
     Player {
         id: player
         sourceName: plasmoid.configuration.sources[plasmoid.configuration.sourceIndex]
+        onReadyChanged: {
+          Plasmoid.status = player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+          console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
     }
 
     compactRepresentation: Item {


### PR DESCRIPTION
Sometimes the widget was visible also when there were no active players or the preferred source player is not active.

Apparently calculating Plasmoid.status using `player.ready` variable doesn't always work.

Fix #60