### PR TITLE
Less verbose plasmoid description

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -7,7 +7,7 @@
                 "Name": "Claudio Catterina"
             }
         ],
-        "Description": "KDE Plasma widget that shows currently playing song information and provide playback controls.",
+        "Description": "Show currently playing song information and provide playback controls",
         "EnabledByDefault": true,
         "Icon": "view-media-track",
         "Id": "plasmusic-toolbar",


### PR DESCRIPTION
The description field in the metadata seems to be used in its tooltip. So I think it's best to make it less verbose.

![plasmusic](https://github.com/ccatterina/plasmusic-toolbar/assets/28627918/ef48c720-3434-41fe-a52d-8745668b0b24)

For reference, this is another plasmoid:

![dictionary](https://github.com/ccatterina/plasmusic-toolbar/assets/28627918/e1bf02a2-8290-4e57-b58f-c7f51400cad6)