### PR TITLE
fix: Enable song text hover behaviours for touchpad

### DIFF
--- a/src/contents/ui/ScrollingText.qml
+++ b/src/contents/ui/ScrollingText.qml
@@ -44,7 +44,7 @@ Item {
 
     HoverHandler {
         id: mouse
-        acceptedDevices: PointerDevice.Mouse
+        acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
     }
 
     TextMetrics {


### PR DESCRIPTION
Song text behaviours `Scroll only on mouse over` and `Always scroll except on mouse over` were not working with touchpad due to the fact that the PointerDevice.TouchPad was not listed in the AcceptedDevices of the HoverHandler component.