### PR TITLE
feat: radius with album image

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -9,6 +9,9 @@
         <entry name="useAlbumCoverAsPanelIcon" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="albumCoverRadius" type="Int">
+            <default>8</default>
+        </entry>
         <entry name="sourceIndex" type="string">
             <default>0</default>
         </entry>

--- a/src/contents/ui/ConfigGeneral.qml
+++ b/src/contents/ui/ConfigGeneral.qml
@@ -8,6 +8,7 @@ import org.kde.kcmutils as KCM
 KCM.SimpleKCM {
     property alias cfg_panelIcon: panelIcon.value
     property alias cfg_useAlbumCoverAsPanelIcon: useAlbumCoverAsPanelIcon.checked
+    property alias cfg_albumCoverRadius: albumCoverRadius.value
     property alias cfg_commandsInPanel: commandsInPanel.checked
     property alias cfg_maxSongWidthInPanel: maxSongWidthInPanel.value
     property alias cfg_sourceIndex: sourceComboBox.currentIndex
@@ -31,6 +32,14 @@ KCM.SimpleKCM {
             id: useAlbumCoverAsPanelIcon
             Kirigami.FormData.label: i18n("Album cover:")
             text: i18n("Use album cover as panel icon")
+        }
+
+        Slider {
+            id: albumCoverRadius
+            from: 0
+            to: 25
+            stepSize: 2
+            Kirigami.FormData.label: i18n("Album cover radius:")
         }
 
         Kirigami.Separator {

--- a/src/contents/ui/PanelIcon.qml
+++ b/src/contents/ui/PanelIcon.qml
@@ -1,13 +1,14 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
+import Qt5Compat.GraphicalEffects
 import org.kde.plasma.components as PlasmaComponents3
 import org.kde.kirigami as Kirigami
-
 
 Item {
     id: root
     property string type: "icon"
     property var imageUrl: null
+    property var imageRadius: null
     property var icon: null
     property real size: Kirigami.Units.iconSizes.medium
 
@@ -40,7 +41,22 @@ Item {
         width: root.size
         height: root.size
         id: imageComponent
+        anchors.fill: parent
         source: root.imageUrl
         fillMode: Image.PreserveAspectFit
+
+        // enables round corners while the radius is set
+        // ref: https://stackoverflow.com/questions/6090740/image-rounded-corners-in-qml
+        layer.enabled: imageRadius > 0
+        layer.effect: OpacityMask {
+            maskSource: Item {
+                width: imageComponent.width
+                height: imageComponent.height
+                Rectangle {
+                    anchors.fill: parent
+                    radius: imageRadius
+                }
+            }
+        }
     }
 }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -45,6 +45,7 @@ PlasmoidItem {
                 size: compact.controlsSize
                 icon: plasmoid.configuration.panelIcon
                 imageUrl: player.artUrl
+                imageRadius: plasmoid.configuration.albumCoverRadius
                 type: plasmoid.configuration.useAlbumCoverAsPanelIcon ? "image": "icon"
                 Layout.rightMargin: Kirigami.Units.smallSpacing * 2
             }


### PR DESCRIPTION
![image](https://github.com/ccatterina/plasmusic-toolbar/assets/17957399/46c56cd4-919d-4feb-a944-34fae5b8f41e)
![image](https://github.com/ccatterina/plasmusic-toolbar/assets/17957399/f3fd29cd-081e-4f5f-acd0-deb45a9be2c4)

- round corner with album image
- add config option `albumCoverRadius`

known issue:
sometimes the Canvas does not repaint after the song is switched, needs to track this issue.
after applying the radius settings, Canvas does not update. (I'm a newer of kde widget development) 