### PR TITLE
fix: text scroll on mouse over not working as expected

### DIFF
--- a/src/contents/ui/ScrollingText.qml
+++ b/src/contents/ui/ScrollingText.qml
@@ -75,6 +75,13 @@ Item {
                 }
             }
 
+            onRunningChanged: () => {
+                // When `running` becomes true the animation start regardless of the `pauseScrolling` value.
+                // Manually pause the animation if the `pauseScrolling` value is true.
+                if (running && root.pauseScrolling) {
+                    pause()
+                }
+            }
             onToChanged: () => reset()
             onDurationChanged: () =>  reset()
         }


### PR DESCRIPTION
After player restart, the first song with text long enough to exceed the available space, started scrolling also if the selected scroll behaviour was "Scroll only on mouse over"