### PR TITLE
feat!: improve preferred source config

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -15,11 +15,14 @@
         <entry name="albumCoverRadius" type="Int">
             <default>8</default>
         </entry>
-        <entry name="sourceIndex" type="string">
-            <default>0</default>
+        <entry name="choosePlayerAutomatically" type="Bool">
+            <default>true</default>
         </entry>
-        <entry name="sources" type="StringList">
-            <default>any,spotify,vlc</default>
+        <entry name="preferredPlayerIdentityIndex" type="Int">
+            <default></default>
+        </entry>
+        <entry name="playersIdentities" type="StringList">
+            <default></default>
         </entry>
         <entry name="maxSongWidthInPanel" type="String">
             <default>200</default>

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -9,19 +9,18 @@ QtObject {
         onRowsInserted: (_, rowIndex) => {
             const CONTAINER_ROLE = Qt.UserRole + 1
             const player = this.data(this.index(rowIndex, 0), CONTAINER_ROLE)
-            if (player.desktopEntry === root.sourceName) {
+            if (player.identity === root.sourceIdentity) {
                 this.currentIndex = rowIndex;
             }
         }
     }
 
-    property string sourceName: "any"
-
+    property var sourceIdentity: null
     readonly property bool ready: {
         if (!mpris2Model.currentPlayer) {
             return false
         }
-        return mpris2Model.currentPlayer.desktopEntry === sourceName || sourceName === "any";
+        return mpris2Model.currentPlayer.identity === sourceIdentity || sourceIdentity === null;
     }
 
     readonly property string artists: ready ? mpris2Model.currentPlayer.artist : ""

--- a/src/contents/ui/SourceDialog.qml
+++ b/src/contents/ui/SourceDialog.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import QtQuick.Dialogs
+import org.kde.plasma.private.mpris as Mpris
+
+Dialog {
+    title: "Choose MPRIS source"
+    modal: true
+    signal sourceSelected(identity: string)
+    property var mpris2Model: Mpris.Mpris2Model {}
+    parent: Overlay.overlay
+    x: Math.round((parent.width - width) / 2)
+    y: Math.round((parent.height - height) / 2)
+    standardButtons: Dialog.Ok | Dialog.Cancel
+    onAccepted: {
+        if (mprisSourceComboBox.currentValue?.identity) {
+            sourceSelected(mprisSourceComboBox.currentValue.identity)
+        }
+    }
+
+    contentItem: Kirigami.FormLayout {
+        Layout.preferredHeight: implicitHeight
+        Layout.minimumHeight: implicitHeight
+        ListModel {
+            id: sources
+            function reload() {
+                sources.clear()
+
+                const CONTAINER_ROLE = Qt.UserRole + 1
+                for (var i = 1; i < mpris2Model.rowCount(); i++) {
+                    const player = mpris2Model.data(mpris2Model.index(i, 0), CONTAINER_ROLE)
+                    sources.append({desktopEntry: player.desktopEntry, identity: player.identity})
+                }
+            }
+            Component.onCompleted: reload()
+        }
+
+        ColumnLayout {
+            Label {
+                text: i18n("Currently running players:")
+            }
+            RowLayout {
+                id: sourceInput
+
+                ComboBox {
+                    id: mprisSourceComboBox
+                    model: sources
+                    textRole: "identity"
+                    currentIndex: 0
+                }
+
+                Button {
+                    icon.name: 'refreshstructure'
+                    onClicked: sources.reload()
+                }
+
+                Kirigami.ContextualHelpButton {
+                    toolTipText: i18n(
+                        "In the dropdown you can choose between all the players that are currently running, " +
+                        "if you can't find the one you want, open the player application and reload the list " +
+                        "with reload button."
+                    )
+                }
+            }
+        }
+    }
+}

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -33,7 +33,12 @@ PlasmoidItem {
 
     Player {
         id: player
-        sourceName: plasmoid.configuration.sources[plasmoid.configuration.sourceIndex]
+        sourceIdentity: {
+            if (plasmoid.configuration.choosePlayerAutomatically) {
+                return null
+            }
+            return plasmoid.configuration.playersIdentities[plasmoid.configuration.preferredPlayerIdentityIndex]
+        }
         onReadyChanged: {
           Plasmoid.status = player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
           console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)


### PR DESCRIPTION
New UX/UI for preferred source configuration:
- Dialog to add new sources from the currently playing ones.
- New informational tooltips to explain how the source config works.
- The selected source is matched with Mpris source `identity` instead of source `desktopEntry`. This make the source match more reliable because some sources (e.g. chromium) haven't a `desktopEntry`.

Fix #107

BREAKING CHANGE: Brake old source config, the preferred source must be reconfigured with the new UI.