### PR TITLE
feat!: improve preferred source config

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -15,11 +15,11 @@
         <entry name="albumCoverRadius" type="Int">
             <default>8</default>
         </entry>
-        <entry name="sourceIndex" type="string">
-            <default>0</default>
+        <entry name="choosePlayerAutomatically" type="Bool">
+            <default>true</default>
         </entry>
-        <entry name="sources" type="StringList">
-            <default>any,spotify,vlc</default>
+        <entry name="preferredPlayerIdentity" type="String">
+            <default></default>
         </entry>
         <entry name="maxSongWidthInPanel" type="String">
             <default>200</default>

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -7,21 +7,23 @@ QtObject {
 
     property var mpris2Model: Mpris.Mpris2Model {
         onRowsInserted: (_, rowIndex) => {
+            if (!sourceIdentity) {
+                return;
+            }
             const CONTAINER_ROLE = Qt.UserRole + 1
             const player = this.data(this.index(rowIndex, 0), CONTAINER_ROLE)
-            if (player.desktopEntry === root.sourceName) {
+            if (player.identity === root.sourceIdentity) {
                 this.currentIndex = rowIndex;
             }
         }
     }
 
-    property string sourceName: "any"
-
+    property var sourceIdentity: null
     readonly property bool ready: {
         if (!mpris2Model.currentPlayer) {
             return false
         }
-        return mpris2Model.currentPlayer.desktopEntry === sourceName || sourceName === "any";
+        return mpris2Model.currentPlayer.identity === sourceIdentity || !sourceIdentity;
     }
 
     readonly property string artists: ready ? mpris2Model.currentPlayer.artist : ""

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -33,7 +33,11 @@ PlasmoidItem {
 
     Player {
         id: player
-        sourceName: plasmoid.configuration.sources[plasmoid.configuration.sourceIndex]
+        sourceIdentity: {
+            if (!plasmoid.configuration.choosePlayerAutomatically) {
+                return plasmoid.configuration.preferredPlayerIdentity
+            }
+        }
         onReadyChanged: {
           Plasmoid.status = player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
           console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)


### PR DESCRIPTION
New UX/UI for preferred source configuration:
- New combobox to select player source from the currently active ones.
- New informational tooltips to explain how the source config works.
- The selected source is matched with Mpris source `identity` instead of source `desktopEntry`. This make the source match more reliable because some sources (e.g. chromium) haven't a `desktopEntry`.

Fix #1078

BREAKING CHANGE: Brake old source config, the preferred source must be reconfigured with the new UI.