### PR TITLE
feat: option to tint widget with cover image dominant color

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -57,5 +57,8 @@
         <entry name="albumPlaceholder" type="String">
             <default></default>
         </entry>
+        <entry name="colorsFromAlbumCover" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -60,5 +60,8 @@
         <entry name="colorsFromAlbumCover" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="panelBackgroundRadius" type="Int">
+            <default>8</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/ConfigGeneral.qml
+++ b/src/contents/ui/ConfigGeneral.qml
@@ -31,6 +31,7 @@ KCM.SimpleKCM {
     property alias cfg_volumeStep: volumeStepSpinbox.value
     property alias cfg_desktopWidgetBg: desktopWidgetBackgroundRadio.value
     property alias cfg_albumPlaceholder: albumPlaceholderDialog.value
+    property alias cfg_colorsFromAlbumCover: colorsFromAlbumCover.checked
 
 
     Kirigami.FormLayout {
@@ -342,6 +343,12 @@ KCM.SimpleKCM {
                     "its content done via a shader. The text color will also invert."
                 )
             }
+        }
+
+        CheckBox {
+            id: colorsFromAlbumCover
+            Kirigami.FormData.label: i18n("Colors from album cover (only for panel applet)")
+            enabled: useAlbumCoverAsPanelIcon.checked
         }
     }
 

--- a/src/contents/ui/ConfigGeneral.qml
+++ b/src/contents/ui/ConfigGeneral.qml
@@ -32,6 +32,7 @@ KCM.SimpleKCM {
     property alias cfg_desktopWidgetBg: desktopWidgetBackgroundRadio.value
     property alias cfg_albumPlaceholder: albumPlaceholderDialog.value
     property alias cfg_colorsFromAlbumCover: colorsFromAlbumCover.checked
+    property alias cfg_panelBackgroundRadius: panelBackgroundRadius.value
 
 
     Kirigami.FormLayout {
@@ -349,6 +350,16 @@ KCM.SimpleKCM {
             id: colorsFromAlbumCover
             Kirigami.FormData.label: i18n("Colors from album cover (only for panel applet)")
             enabled: useAlbumCoverAsPanelIcon.checked
+        }
+
+        Slider {
+            Layout.preferredWidth: 10 * Kirigami.Units.gridUnit
+            enabled: colorsFromAlbumCover.checked
+            id: panelBackgroundRadius
+            from: 0
+            to: 25
+            stepSize: 2
+            Kirigami.FormData.label: i18n("Colored background radius:")
         }
     }
 

--- a/src/contents/ui/PanelIcon.qml
+++ b/src/contents/ui/PanelIcon.qml
@@ -19,6 +19,7 @@ Item {
     property bool imageReady: false
     property bool fallbackToIconWhenImageNotAvailable: false
     visible: type === PanelIcon.Type.Icon || imageReady || (fallbackToIconWhenImageNotAvailable && !imageReady)
+    signal imageColorChanged(color: var)
 
     Layout.preferredHeight: size
     Layout.preferredWidth: size
@@ -50,6 +51,13 @@ Item {
         fillMode: Image.PreserveAspectFit
         onStatusChanged: {
             imageStatusTimer.restart()
+            if (status === Image.Ready) imageColors.update()
+        }
+
+        // update color when image becomes visible, otherwise we get black color
+        // sometimes, specially when the widget first loads
+        onVisibleChanged: {
+            if (status === Image.Ready) imageColors.update()
         }
 
         // enables round corners while the radius is set
@@ -64,6 +72,14 @@ Item {
                     radius: imageRadius
                 }
             }
+        }
+    }
+
+    Kirigami.ImageColors {
+        id: imageColors
+        source: imageComponent
+        onPaletteChanged: {
+            imageColorChanged(dominant)
         }
     }
 }

--- a/src/contents/ui/ScrollingText.qml
+++ b/src/contents/ui/ScrollingText.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
 
 // inspired by https://stackoverflow.com/a/49031115/2568933
 Item {
@@ -17,6 +18,7 @@ Item {
     property string text: ""
     readonly property string spacing: "     "
     readonly property string textAndSpacing: text + spacing
+    property color textColor: Kirigami.Theme.textColor
 
     property int maxWidth: 200 * units.devicePixelRatio
     readonly property bool overflow: maxWidth <= textMetrics.width
@@ -59,6 +61,7 @@ Item {
     PlasmaComponents3.Label {
         id: label
         text: overflow ? root.textAndSpacing : root.text
+        color: root.textColor
 
         NumberAnimation on x {
             running: root.overflow && root.scrollingEnabled
@@ -95,7 +98,7 @@ Item {
         PlasmaComponents3.Label {
             visible: overflow
             anchors.left: parent.right
-
+            color: root.textColor
             font: label.font
             text: label.text
         }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -48,8 +48,8 @@ PlasmoidItem {
     compactRepresentation: Item {
         id: compact
 
-        Layout.preferredWidth: grid.implicitWidth + Kirigami.Units.smallSpacing * 2
-        Layout.preferredHeight: grid.implicitHeight + Kirigami.Units.smallSpacing * 2
+        Layout.preferredWidth: grid.implicitWidth + (horizontal ? lengthMargin : 0)
+        Layout.preferredHeight: grid.implicitHeight + (horizontal ? 0 : lengthMargin)
         Layout.fillHeight: horizontal
         Layout.fillWidth: !horizontal
         readonly property bool colorsFromAlbumCover: plasmoid.configuration.colorsFromAlbumCover
@@ -131,7 +131,7 @@ PlasmoidItem {
             rowSpacing: Kirigami.Units.smallSpacing
             columns: horizontal ? grid.children.length : 1
             rows: horizontal ? 1 : grid.children.length
-            anchors.fill: parent
+            anchors.centerIn: parent
 
             PanelIcon {
                 size: compact.controlsSize

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -52,8 +52,28 @@ PlasmoidItem {
         Layout.preferredHeight: grid.implicitHeight + Kirigami.Units.smallSpacing * 2
         Layout.fillHeight: horizontal
         Layout.fillWidth: !horizontal
+        readonly property bool colorsFromAlbumCover: plasmoid.configuration.colorsFromAlbumCover
+        property color imageColor: Kirigami.Theme.textColor
+        property bool imageReady: false
+        property string backgroundColor: imageReady && colorsFromAlbumCover ? Kirigami.ColorUtils.tintWithAlpha(imageColor, "#000000", 0.5) : "transparent"
+        property string foregroundColor: imageReady && colorsFromAlbumCover ? Kirigami.ColorUtils.tintWithAlpha(imageColor, contrastColor, .6) : Kirigami.Theme.textColor
+        property string contrastColor: Kirigami.ColorUtils.brightnessForColor(backgroundColor) === Kirigami.ColorUtils.Dark ? "#ffffff" : "#000000"
 
-        readonly property real controlsSize: Math.min(height, Kirigami.Units.iconSizes.medium)
+        readonly property int widgetThickness: Math.min(height, width)
+        readonly property int controlsSize: Math.round(widgetThickness * 0.75)
+        readonly property int lengthMargin: Math.round((widgetThickness - controlsSize))
+
+        Behavior on backgroundColor {
+            ColorAnimation {
+                duration: Kirigami.Units.longDuration
+            }
+        }
+
+        Behavior on foregroundColor {
+            ColorAnimation {
+                duration: Kirigami.Units.longDuration
+            }
+        }
 
         MouseArea {
             anchors.fill: parent
@@ -99,6 +119,11 @@ PlasmoidItem {
             z: 999
         }
 
+        Rectangle {
+            anchors.fill: parent
+            color: backgroundColor
+        }
+
         GridLayout {
             id: grid
             columnSpacing: Kirigami.Units.smallSpacing
@@ -120,6 +145,16 @@ PlasmoidItem {
                     return PanelIcon.Type.Image;
                 }
                 Layout.alignment : Qt.AlignVCenter | Qt.AlignHCenter
+                onTypeChanged: {
+                    compact.imageReady = type === PanelIcon.Type.Image && imageReady
+                }
+                onImageColorChanged: (color) => {
+                    compact.imageColor = color
+                }
+                onImageReadyChanged: {
+                    if (type === PanelIcon.Type.Image)
+                    compact.imageReady = imageReady
+                }
             }
 
             Item {
@@ -145,6 +180,7 @@ PlasmoidItem {
                         text: player.title
                         scrollingEnabled: textScrollingEnabled
                         scrollResetOnPause: textScrollingResetOnPause
+                        textColor: foregroundColor
                     }
                     ScrollingText {
                         overflowBehaviour: plasmoid.configuration.textScrollingBehaviour
@@ -155,6 +191,7 @@ PlasmoidItem {
                         scrollingEnabled: textScrollingEnabled
                         scrollResetOnPause: textScrollingResetOnPause
                         visible: text.length !== 0
+                        textColor: foregroundColor
                     }
                 }
             }
@@ -170,6 +207,7 @@ PlasmoidItem {
                     onClicked: player.previous()
                 }
                 Layout.alignment : Qt.AlignVCenter | Qt.AlignHCenter
+                icon.color: foregroundColor
             }
 
             PlasmaComponents3.ToolButton {
@@ -183,6 +221,7 @@ PlasmoidItem {
                     onClicked: player.playPause()
                 }
                 Layout.alignment : Qt.AlignVCenter | Qt.AlignHCenter
+                icon.color: foregroundColor
             }
 
             PlasmaComponents3.ToolButton {
@@ -196,6 +235,7 @@ PlasmoidItem {
                     onClicked: player.next()
                 }
                 Layout.alignment : Qt.AlignVCenter | Qt.AlignHCenter
+                icon.color: foregroundColor
             }
         }
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -122,6 +122,7 @@ PlasmoidItem {
         Rectangle {
             anchors.fill: parent
             color: backgroundColor
+            radius: plasmoid.configuration.panelBackgroundRadius
         }
 
         GridLayout {


### PR DESCRIPTION
Depends on https://github.com/ccatterina/plasmusic-toolbar/pull/150

closes: https://github.com/ccatterina/plasmusic-toolbar/issues/120
