### PR TITLE
improve: add contextual help for background color option

### DIFF
--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -275,10 +275,17 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Background")
         }
 
-        CheckBox {
-            id: colorsFromAlbumCover
-            enabled: useAlbumCoverAsPanelIcon.checked
+        RowLayout {
             Kirigami.FormData.label: i18n("Colors from album cover")
+            enabled: useAlbumCoverAsPanelIcon.checked
+
+            CheckBox {
+                id: colorsFromAlbumCover
+            }
+
+            Kirigami.ContextualHelpButton {
+                toolTipText: i18n("Use album cover as icon should be checked for background to work.")
+            }
         }
 
         Slider {


### PR DESCRIPTION
A contextual help button  to clarify that "Background" section requires Use album cover as icon" to be enabled.