### PR TITLE
fix: plasmusic overlaps with other widgets in the panel

### DIFF
--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -16,6 +16,8 @@ Item {
 
     Layout.preferredWidth: horizontal ? grid.implicitWidth + lengthMargin * 2 : grid.implicitWidth
     Layout.preferredHeight: !horizontal ? grid.implicitHeight + lengthMargin * 2 : grid.implicitHeight
+    Layout.minimumWidth: Layout.preferredWidth
+    Layout.minimumHeight: Layout.preferredHeight
     Layout.fillHeight: horizontal || fillAvailableSpace
     Layout.fillWidth: !horizontal || fillAvailableSpace
 


### PR DESCRIPTION
When there was not enough space plasmusic overlapped with the other widgets in the panel.

Closes #169 