### PR TITLE
feat: increase panel icon and controls size ratio limit to 1

### DIFF
--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -144,7 +144,7 @@ KCM.SimpleKCM {
             Layout.preferredWidth: 10 * Kirigami.Units.gridUnit
             id: panelIconSizeRatio
             from: 0.6
-            to: 0.95
+            to: 1
             stepSize: 0.05
             Kirigami.FormData.label: i18n("Size:")
         }
@@ -288,7 +288,7 @@ KCM.SimpleKCM {
             Layout.preferredWidth: 10 * Kirigami.Units.gridUnit
             id: panelControlsSizeRatio
             from: 0.6
-            to: 0.95
+            to: 1
             stepSize: 0.05
             Kirigami.FormData.label: i18n("Size:")
         }


### PR DESCRIPTION
Icon and controls size ratio was previously limited to 0.95 to always
leave a bit of background color margin when the colors from album cover
option was enabled.
The margin is no longer needed, as the UI looks fine without it.

See https://github.com/ccatterina/plasmusic-toolbar/issues/178#issuecomment-2848481637