### PR TITLE
feat: show placeholder image when album art loading fails

### DIFF
--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -31,7 +31,13 @@ Item {
 
             Image {
                 anchors.fill: parent
-                source: player.artUrl || albumPlaceholder
+                source: {
+                    if (status === Image.Error || !player.artUrl) {
+                        return albumPlaceholder;
+                    }
+                    return player.artUrl;
+                }
+
                 fillMode: Image.PreserveAspectFit
                 MouseArea {
                     id: coverMouseArea


### PR DESCRIPTION
Previously, placeholder was only shown when album art URL was missing.