### PR TITLE
Add an option to display album title and configure where it displays

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -103,7 +103,7 @@
             <default>1</default>
         </entry>
         <entry name="artistsPosition" type="Int">
-            <default>2</default>
+            <default>1</default>
         </entry>
         <entry name="albumPosition" type="Int">
             <default>0</default>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -45,9 +45,6 @@
         <entry name="textScrollingSpeed" type="Int">
             <default>3</default>
         </entry>
-        <entry name="separateText" type="Bool">
-            <default>false</default>
-        </entry>
         <entry name="textScrollingBehaviour" type="Int">
             <default>0</default>
         </entry>
@@ -102,11 +99,14 @@
         <entry name="panelControlsSizeRatio" type="Double">
             <default>0.75</default>
         </entry>
-        <entry name="showAlbumTitle" type="Bool">
-            <default>true</default>
+        <entry name="titleDisplay" type="Int">
+            <default>1</default>
         </entry>
-        <entry name="albumBeneathSongAndArtists" type="Bool">
-            <default>true</default>
+        <entry name="artistsDisplay" type="Int">
+            <default>2</default>
+        </entry>
+        <entry name="albumDisplay" type="Int">
+            <default>0</default>
         </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -108,5 +108,11 @@
         <entry name="albumBeneathSongAndArtists" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="boldSongTitle" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="italiciseAlbumTitle" type="Bool">
+            <default>true</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -115,7 +115,7 @@
             <default>2</default>
         </entry>
         <entry name="fullAlbumPosition" type="Int">
-            <default>3</default>
+            <default>2</default>
         </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -102,5 +102,11 @@
         <entry name="panelControlsSizeRatio" type="Double">
             <default>0.75</default>
         </entry>
+        <entry name="showAlbumTitle" type="Bool">
+            <default>true</default>
+        </entry>
+        <entry name="albumBeneathSongAndArtists" type="Bool">
+            <default>true</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -108,11 +108,5 @@
         <entry name="albumBeneathSongAndArtists" type="Bool">
             <default>true</default>
         </entry>
-        <entry name="boldSongTitle" type="Bool">
-            <default>true</default>
-        </entry>
-        <entry name="italiciseAlbumTitle" type="Bool">
-            <default>true</default>
-        </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -99,14 +99,23 @@
         <entry name="panelControlsSizeRatio" type="Double">
             <default>0.75</default>
         </entry>
-        <entry name="titleDisplay" type="Int">
+        <entry name="titlePosition" type="Int">
             <default>1</default>
         </entry>
-        <entry name="artistsDisplay" type="Int">
+        <entry name="artistsPosition" type="Int">
             <default>2</default>
         </entry>
-        <entry name="albumDisplay" type="Int">
+        <entry name="albumPosition" type="Int">
             <default>0</default>
+        </entry>
+        <entry name="fullTitlePosition" type="Int">
+            <default>1</default>
+        </entry>
+        <entry name="fullArtistsPosition" type="Int">
+            <default>2</default>
+        </entry>
+        <entry name="fullAlbumPosition" type="Int">
+            <default>3</default>
         </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -161,7 +161,6 @@ Item {
                 Layout.fillWidth: !horizontal
                 Layout.preferredHeight: !horizontal ? songAndArtistText.width : null
                 Layout.preferredWidth: horizontal ? songAndArtistText.width : null
-                //                                               the +10 is for padding
 
                 SongAndArtistText {
                     id: songAndArtistText

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -159,8 +159,9 @@ Item {
             Item {
                 Layout.fillHeight: horizontal
                 Layout.fillWidth: !horizontal
-                Layout.preferredHeight: !horizontal ? songAndArtistText.width : null
-                Layout.preferredWidth: horizontal ? songAndArtistText.width : null
+                Layout.preferredHeight: !horizontal ? songAndArtistText.width : null // is this not supposed to be height?
+                Layout.preferredWidth: horizontal ? songAndArtistText.width + 10 : null
+                //                                               the +10 is for padding
 
                 SongAndArtistText {
                     id: songAndArtistText
@@ -183,6 +184,8 @@ Item {
                     scrollingSpeed: plasmoid.configuration.textScrollingSpeed
                     scrollingResetOnPause: plasmoid.configuration.textScrollingResetOnPause
                     scrollingEnabled: plasmoid.configuration.textScrollingEnabled
+                    showAlbumTitle: plasmoid.configuration.showAlbumTitle
+                    albumBeneathSongAndArtists: plasmoid.configuration.albumBeneathSongAndArtists
                     forcePauseScrolling: {
                         if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
                             return false
@@ -193,6 +196,7 @@ Item {
                     color: foregroundColor
                     title: player.title
                     artists: player.artists
+                    album: player.album
                     textAlignment: songGrid.textAlignment
                 }
             }

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -179,13 +179,13 @@ Item {
                         }
                         return plasmoid.configuration.maxSongWidthInPanel
                     }
-                    splitSongAndArtists: plasmoid.configuration.separateText
                     scrollingBehaviour: plasmoid.configuration.textScrollingBehaviour
                     scrollingSpeed: plasmoid.configuration.textScrollingSpeed
                     scrollingResetOnPause: plasmoid.configuration.textScrollingResetOnPause
                     scrollingEnabled: plasmoid.configuration.textScrollingEnabled
-                    showAlbumTitle: plasmoid.configuration.showAlbumTitle
-                    albumBeneathSongAndArtists: plasmoid.configuration.albumBeneathSongAndArtists
+                    titlePosition: plasmoid.configuration.titlePosition
+                    artistsPosition: plasmoid.configuration.artistsPosition
+                    albumPosition: plasmoid.configuration.albumPosition
                     forcePauseScrolling: {
                         if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
                             return false

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -159,8 +159,8 @@ Item {
             Item {
                 Layout.fillHeight: horizontal
                 Layout.fillWidth: !horizontal
-                Layout.preferredHeight: !horizontal ? songAndArtistText.width : null // is this not supposed to be height?
-                Layout.preferredWidth: horizontal ? songAndArtistText.width + 10 : null
+                Layout.preferredHeight: !horizontal ? songAndArtistText.width : null
+                Layout.preferredWidth: horizontal ? songAndArtistText.width : null
                 //                                               the +10 is for padding
 
                 SongAndArtistText {

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -186,8 +186,6 @@ Item {
                     scrollingEnabled: plasmoid.configuration.textScrollingEnabled
                     showAlbumTitle: plasmoid.configuration.showAlbumTitle
                     albumBeneathSongAndArtists: plasmoid.configuration.albumBeneathSongAndArtists
-                    italiciseAlbumTitle: plasmoid.configuration.italiciseAlbumTitle
-                    boldSongTitle: plasmoid.configuration.boldSongTitle
                     forcePauseScrolling: {
                         if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
                             return false

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -186,6 +186,8 @@ Item {
                     scrollingEnabled: plasmoid.configuration.textScrollingEnabled
                     showAlbumTitle: plasmoid.configuration.showAlbumTitle
                     albumBeneathSongAndArtists: plasmoid.configuration.albumBeneathSongAndArtists
+                    italiciseAlbumTitle: plasmoid.configuration.italiciseAlbumTitle
+                    boldSongTitle: plasmoid.configuration.boldSongTitle
                     forcePauseScrolling: {
                         if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
                             return false

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -75,14 +75,14 @@ Item {
         SongAndArtistText {
             Layout.alignment: Qt.AlignHCenter
             scrollingSpeed: plasmoid.configuration.fullViewTextScrollingSpeed
-            splitSongAndArtists: true
-            showAlbumTitle: true
-            albumBeneathSongAndArtists: true
             title: player.title
             artists: player.artists
             album: player.album
             textFont: baseFont
             maxWidth: 250
+            titlePosition: 1
+            artistsPosition: 2
+            albumPosition: 2
         }
 
         VolumeBar {

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -80,9 +80,9 @@ Item {
             album: player.album
             textFont: baseFont
             maxWidth: 250
-            titlePosition: 1
-            artistsPosition: 2
-            albumPosition: 2
+            titlePosition: plasmoid.configuration.fullTitlePosition
+            artistsPosition: plasmoid.configuration.fullArtistsPosition
+            albumPosition: plasmoid.configuration.fullAlbumPosition
         }
 
         VolumeBar {

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -76,8 +76,11 @@ Item {
             Layout.alignment: Qt.AlignHCenter
             scrollingSpeed: plasmoid.configuration.fullViewTextScrollingSpeed
             splitSongAndArtists: true
+            showAlbumTitle: true
+            albumBeneathSongAndArtists: true
             title: player.title
             artists: player.artists
+            album: player.album
             textFont: baseFont
             maxWidth: 250
         }

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -83,6 +83,9 @@ Item {
             album: player.album
             textFont: baseFont
             maxWidth: 250
+
+            italiciseAlbumTitle: true
+            boldSongTitle: true
         }
 
         VolumeBar {

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -83,9 +83,6 @@ Item {
             album: player.album
             textFont: baseFont
             maxWidth: 250
-
-            italiciseAlbumTitle: true
-            boldSongTitle: true
         }
 
         VolumeBar {

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -28,6 +28,7 @@ QtObject {
 
     readonly property string artists: ready ? mpris2Model.currentPlayer.artist : ""
     readonly property string title: ready ? mpris2Model.currentPlayer.track : ""
+    readonly property string album: ready ? mpris2Model.currentPlayer.album : ""
     readonly property int playbackStatus: ready ? mpris2Model.currentPlayer.playbackStatus : Mpris.PlaybackStatus.Unknown
     readonly property int shuffle: ready ? mpris2Model.currentPlayer.shuffle : Mpris.ShuffleStatus.Unknown
     readonly property string artUrl: ready ? mpris2Model.currentPlayer.artUrl : ""

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -50,11 +50,11 @@ Item {
 
     property alias font: label.font
 
-    width: overflow ? maxWidth : textMetrics.width // to account for the bolded/italicised text
+    width: overflow ? maxWidth : textMetrics.width
     
     clip: overflow 
-    // only clip if overflowing. this stops the song title from being clipped because it is bolded,
-    // so it is slightly wider than textMetrics.width expects
+    // only clip if overflowing. this stops the song title from being clipped because it is bolded / italicised / whatever,
+    // causing it to be slightly wider than textMetrics.width expects
 
 
     Layout.preferredHeight: label.implicitHeight

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -7,6 +7,10 @@ import org.kde.kirigami as Kirigami
 Item {
     id: root
 
+    function removeHTML (htmlString) {
+        return htmlString.replace(/<[^>]*>/g,"");
+    }
+
     enum OverflowBehaviour {
         AlwaysScroll,
         ScrollOnMouseOver,
@@ -46,8 +50,12 @@ Item {
 
     property alias font: label.font
 
-    width: overflow ? maxWidth : label.implicitWidth
-    clip: true
+    width: overflow ? maxWidth : textMetrics.width // to account for the bolded/italicised text
+    
+    clip: overflow 
+    // only clip if overflowing. this stops the song title from being clipped because it is bolded,
+    // so it is slightly wider than textMetrics.width expects
+
 
     Layout.preferredHeight: label.implicitHeight
     Layout.preferredWidth: width
@@ -61,7 +69,7 @@ Item {
     TextMetrics {
         id: textMetrics
         font: label.font
-        text: root.text
+        text: root.removeHTML(root.text)
     }
 
     PlasmaComponents3.Label {

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -7,10 +7,6 @@ import org.kde.kirigami as Kirigami
 Item {
     id: root
 
-    function removeHTML (htmlString) {
-        return htmlString.replace(/<[^>]*>/g,"");
-    }
-
     enum OverflowBehaviour {
         AlwaysScroll,
         ScrollOnMouseOver,
@@ -66,7 +62,7 @@ Item {
     TextMetrics {
         id: textMetrics
         font: label.font
-        text: root.removeHTML(root.text)
+        text: root.text
     }
 
     PlasmaComponents3.Label {

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -16,7 +16,9 @@ Item {
     property int overflowBehaviour: ScrollingText.OverflowBehaviour.AlwaysScroll
 
     property string text: ""
-    readonly property string spacing: "     "
+
+    // 15 spaces. use &nbsp; because it works with the html tags used for styling the song text
+    readonly property string spacing: "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
     readonly property string textAndSpacing: text + spacing
     property color textColor: Kirigami.Theme.textColor
 
@@ -44,7 +46,7 @@ Item {
 
     property alias font: label.font
 
-    width: overflow ? maxWidth : textMetrics.width
+    width: overflow ? maxWidth : label.implicitWidth
     clip: true
 
     Layout.preferredHeight: label.implicitHeight

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -52,8 +52,6 @@ Item {
     width: overflow ? maxWidth : textMetrics.width
     
     clip: overflow 
-    // only clip if overflowing. this stops the song title from being clipped because it is bolded / italicised / whatever,
-    // causing it to be slightly wider than textMetrics.width expects
 
 
     Layout.preferredHeight: label.implicitHeight

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -16,8 +16,7 @@ Item {
     property int overflowBehaviour: ScrollingText.OverflowBehaviour.AlwaysScroll
 
     property string text: ""
-
-    readonly property string spacing: "          "
+    readonly property string spacing: "     "
     readonly property string textAndSpacing: text + spacing
     property color textColor: Kirigami.Theme.textColor
 
@@ -46,9 +45,7 @@ Item {
     property alias font: label.font
 
     width: overflow ? maxWidth : textMetrics.width
-    
     clip: overflow 
-
 
     Layout.preferredHeight: label.implicitHeight
     Layout.preferredWidth: width

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -21,8 +21,7 @@ Item {
 
     property string text: ""
 
-    // 15 spaces. use &nbsp; because it works with the html tags used for styling the song text
-    readonly property string spacing: "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+    readonly property string spacing: "          "
     readonly property string textAndSpacing: text + spacing
     property color textColor: Kirigami.Theme.textColor
 

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -15,8 +15,6 @@ ColumnLayout {
     property bool splitSongAndArtists: false
     property bool showAlbumTitle: true
     property bool albumBeneathSongAndArtists: true
-    property bool italiciseAlbumTitle: true
-    property bool boldSongTitle: true
 
     property font textFont: Kirigami.Theme.defaultFont
     // property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
@@ -29,11 +27,9 @@ ColumnLayout {
 
     spacing: 0
 
-    // [root.artists, root.title].filter((x) => x).join(" - ")
-
-    property string formattedTitle: boldSongTitle ? `<b>${root.title}</b>` : root.title
+    property string formattedTitle: `${root.title}`
     property string formattedArtists: `${root.artists}`
-    property string formattedAlbum: italiciseAlbumTitle ? `<i>${root.album}</i>` : root.album
+    property string formattedAlbum: `${root.album}`
 
     property string finalFirstText: {
         if (root.showAlbumTitle) {

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -6,19 +6,19 @@ import org.kde.kirigami as Kirigami
 ColumnLayout {
     id: root
 
-    property var maxWidth: undefined
-    property var scrollingBehaviour: undefined
-    property var scrollingSpeed: undefined
-    property var scrollingResetOnPause: undefined
-    property var scrollingEnabled: undefined
-    property var forcePauseScrolling: undefined
+    property int maxWidth: undefined
+    property int scrollingBehaviour: undefined
+    property int scrollingSpeed: undefined
+    property bool scrollingResetOnPause: undefined
+    property bool scrollingEnabled: undefined
+    property bool forcePauseScrolling: undefined
     property bool splitSongAndArtists: false
     property bool showAlbumTitle: true
     property bool albumBeneathSongAndArtists: true
 
     property font textFont: Kirigami.Theme.defaultFont
-    property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
-    property font italicTextFont: Qt.font(Object.assign({}, textFont, {italic: true}))
+    // property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
+    // property font italicTextFont: Qt.font(Object.assign({}, textFont, {italic: true}))
     property string color: Kirigami.Theme.textColor
     property string title
     property string artists

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -12,9 +12,12 @@ ColumnLayout {
     property var scrollingResetOnPause: undefined
     property var scrollingEnabled: undefined
     property var forcePauseScrolling: undefined
-    property bool splitSongAndArtists: false
-    property bool showAlbumTitle: true
-    property bool albumBeneathSongAndArtists: true
+
+    // 0 is hidden, 1 is first line, 2 is second line
+
+    property int titlePosition: 1
+    property int artistsPosition: 1
+    property int albumPosition: 0
 
     property font textFont: Kirigami.Theme.defaultFont
     // property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
@@ -31,57 +34,33 @@ ColumnLayout {
     property string formattedArtists: `${root.artists}`
     property string formattedAlbum: `${root.album}`
 
-    property string finalFirstText: {
-        if (root.showAlbumTitle) {
-            if (root.albumBeneathSongAndArtists) {
-                if (splitSongAndArtists) {
-                    return formattedTitle
-                } else {
-                    return [formattedArtists,formattedTitle].filter((x) => x).join(" - ")
-                }
-            } else {
-                if (splitSongAndArtists) {
-                    return [formattedTitle,formattedAlbum].filter((x) => x).join(" - ")
-                } else {
-                    return [formattedArtists,formattedTitle,formattedAlbum].filter((x) => x).join(" - ")
-                }
-            }
-        } else {
-            if (root.splitSongAndArtists) {
-                return formattedTitle
-            } else {
-                return [formattedArtists,formattedTitle].filter((x) => x).join(" - ")
-            }
-        }
+    property var firstLineArray: {
+        const arr = [];
+
+        if (artistsPosition == 1) arr.push(root.formattedArtists);
+        if (titlePosition   == 1) arr.push(root.formattedTitle);
+        if (albumPosition   == 1) arr.push(root.formattedAlbum);
+
+        return arr;
     }
 
-    property string finalSecondText: {
-        if (root.showAlbumTitle) {
-            if (root.albumBeneathSongAndArtists) {
-                if (splitSongAndArtists) {
-                    return [formattedArtists,formattedAlbum].filter((x) => x).join(" - ")
-                } else {
-                    return formattedAlbum
-                }
-            } else {
-                if (splitSongAndArtists) {
-                    return formattedArtists
-                } else {
-                    return ""
-                }
-            }
-        } else {
-            if (root.splitSongAndArtists) {
-                return formattedArtists
-            } else {
-                return ""
-            }
-        }
+    property var secondLineArray: {
+        const arr = [];
+
+        if (artistsPosition == 2) arr.push(root.formattedArtists);
+        if (titlePosition   == 2) arr.push(root.formattedTitle);
+        if (albumPosition   == 2) arr.push(root.formattedAlbum);
+
+        return arr;        
     }
+
+    property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
+    property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
 
     // first row of text (the only row, if there is only one)
     ScrollingText {
-        // always visible
+        // visible only when necessary
+        visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour
         font: root.textFont
         speed: root.scrollingSpeed
@@ -113,34 +92,4 @@ ColumnLayout {
         forcePauseScrolling: root.forcePauseScrolling
         Layout.alignment: root.textAlignment
     }
-
-    // // top text
-    // ScrollingText {
-    //     visible: root.splitSongAndArtists
-    //     overflowBehaviour: root.scrollingBehaviour
-    //     font: root.boldTextFont
-    //     speed: root.scrollingSpeed
-    //     maxWidth: root.maxWidth
-    //     text: root.title
-    //     scrollingEnabled: root.scrollingEnabled
-    //     scrollResetOnPause: root.scrollingResetOnPause
-    //     textColor: root.color
-    //     forcePauseScrolling: root.forcePauseScrolling
-    //     Layout.alignment: root.textAlignment
-    // }
-
-    // // second row of text
-    // ScrollingText {
-    //     overflowBehaviour: root.scrollingBehaviour
-    //     font: root.textFont
-    //     speed: root.scrollingSpeed
-    //     maxWidth: root.maxWidth
-    //     text: root.splitSongAndArtists ? root.artists : [root.artists, root.title].filter((x) => x).join(" - ")
-    //     scrollingEnabled: root.scrollingEnabled
-    //     scrollResetOnPause: root.scrollingResetOnPause
-    //     visible: text.length !== 0
-    //     textColor: root.color
-    //     forcePauseScrolling: root.forcePauseScrolling
-    //     Layout.alignment: root.textAlignment
-    // }
 }

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -6,15 +6,17 @@ import org.kde.kirigami as Kirigami
 ColumnLayout {
     id: root
 
-    property int maxWidth: undefined
-    property int scrollingBehaviour: undefined
-    property int scrollingSpeed: undefined
-    property bool scrollingResetOnPause: undefined
-    property bool scrollingEnabled: undefined
-    property bool forcePauseScrolling: undefined
+    property var maxWidth: undefined
+    property var scrollingBehaviour: undefined
+    property var scrollingSpeed: undefined
+    property var scrollingResetOnPause: undefined
+    property var scrollingEnabled: undefined
+    property var forcePauseScrolling: undefined
     property bool splitSongAndArtists: false
     property bool showAlbumTitle: true
     property bool albumBeneathSongAndArtists: true
+    property bool italiciseAlbumTitle: true
+    property bool boldSongTitle: true
 
     property font textFont: Kirigami.Theme.defaultFont
     // property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
@@ -29,9 +31,9 @@ ColumnLayout {
 
     // [root.artists, root.title].filter((x) => x).join(" - ")
 
-    property string formattedTitle: `<b>${root.title}</b>`
+    property string formattedTitle: boldSongTitle ? `<b>${root.title}</b>` : root.title
     property string formattedArtists: `${root.artists}`
-    property string formattedAlbum: `<i>${root.album}</i>`
+    property string formattedAlbum: italiciseAlbumTitle ? `<i>${root.album}</i>` : root.album
 
     property string finalFirstText: {
         if (root.showAlbumTitle) {

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -6,6 +6,13 @@ import org.kde.kirigami as Kirigami
 ColumnLayout {
     id: root
 
+    enum TextPosition {
+        Hidden,
+        FirstLine,
+        SecondLine,
+        ThirdLine
+    }
+
     property var maxWidth: undefined
     property var scrollingBehaviour: undefined
     property var scrollingSpeed: undefined
@@ -15,9 +22,9 @@ ColumnLayout {
 
     // 0 is hidden, 1 is first line, 2 is second line
 
-    property int titlePosition: 1
-    property int artistsPosition: 1
-    property int albumPosition: 0
+    property int titlePosition: SongAndArtistText.TextPosition.FirstLine
+    property int artistsPosition: SongAndArtistText.TextPosition.FirstLine
+    property int albumPosition: SongAndArtistText.TextPosition.Hidden
 
     property font textFont: Kirigami.Theme.defaultFont
     property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
@@ -29,12 +36,13 @@ ColumnLayout {
 
     spacing: 0
 
+
     property var firstLineArray: {
         const arr = [];
 
-        if (artistsPosition == 1) arr.push(root.artists);
-        if (titlePosition   == 1) arr.push(root.title);
-        if (albumPosition   == 1) arr.push(root.album);
+        if (artistsPosition == SongAndArtistText.TextPosition.FirstLine) arr.push(root.artists);
+        if (titlePosition   == SongAndArtistText.TextPosition.FirstLine) arr.push(root.title);
+        if (albumPosition   == SongAndArtistText.TextPosition.FirstLine) arr.push(root.album);
 
         return arr;
     }
@@ -42,27 +50,25 @@ ColumnLayout {
     property var secondLineArray: {
         const arr = [];
 
-        if (artistsPosition == 2) arr.push(root.artists);
-        if (titlePosition   == 2) arr.push(root.title);
-        if (albumPosition   == 2) arr.push(root.album);
+        if (artistsPosition == SongAndArtistText.TextPosition.SecondLine) arr.push(root.artists);
+        if (titlePosition   == SongAndArtistText.TextPosition.SecondLine) arr.push(root.title);
+        if (albumPosition   == SongAndArtistText.TextPosition.SecondLine) arr.push(root.album);
 
         return arr;        
     }
 
-    property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
-    property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
-
-    // ONLY USED FOR FULL.qml
     property var thirdLineArray: {
         const arr = [];
 
-        if (artistsPosition == 3) arr.push(root.artists);
-        if (titlePosition   == 3) arr.push(root.title);
-        if (albumPosition   == 3) arr.push(root.album);
+        if (artistsPosition == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.artists);
+        if (albumPosition   == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.album);
+        if (titlePosition   == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.title);
 
         return arr;   
     }
 
+    property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
+    property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
     property string finalThirdText: thirdLineArray.filter((x) => x).join(" - ")
 
     // first row of text (the only row, if there is only one)

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -9,8 +9,7 @@ ColumnLayout {
     enum TextPosition {
         Hidden,
         FirstLine,
-        SecondLine,
-        ThirdLine
+        SecondLine
     }
 
     property var maxWidth: undefined
@@ -56,19 +55,8 @@ ColumnLayout {
         return arr;        
     }
 
-    property var thirdLineArray: {
-        const arr = [];
-
-        if (artistsPosition == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.artists);
-        if (albumPosition   == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.album);
-        if (titlePosition   == SongAndArtistText.TextPosition.ThirdLine) arr.push(root.title);
-
-        return arr;   
-    }
-
     property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
     property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
-    property string finalThirdText: thirdLineArray.filter((x) => x).join(" - ")
 
     // first row of text (the only row, if there is only one)
     ScrollingText {
@@ -98,23 +86,6 @@ ColumnLayout {
         maxWidth: root.maxWidth
 
         text: root.finalSecondText
-        
-        scrollingEnabled: root.scrollingEnabled
-        scrollResetOnPause: root.scrollingResetOnPause
-        textColor: root.color
-        forcePauseScrolling: root.forcePauseScrolling
-        Layout.alignment: root.textAlignment
-    }
-
-    ScrollingText {
-        // visible only when necessary
-        visible: text.length !== 0
-        overflowBehaviour: root.scrollingBehaviour
-        font: root.textFont
-        speed: root.scrollingSpeed
-        maxWidth: root.maxWidth
-
-        text: root.finalThirdText
         
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -20,8 +20,7 @@ ColumnLayout {
     property int albumPosition: 0
 
     property font textFont: Kirigami.Theme.defaultFont
-    // property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
-    // property font italicTextFont: Qt.font(Object.assign({}, textFont, {italic: true}))
+    property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
     property string color: Kirigami.Theme.textColor
     property string title
     property string artists
@@ -30,16 +29,12 @@ ColumnLayout {
 
     spacing: 0
 
-    property string formattedTitle: `${root.title}`
-    property string formattedArtists: `${root.artists}`
-    property string formattedAlbum: `${root.album}`
-
     property var firstLineArray: {
         const arr = [];
 
-        if (artistsPosition == 1) arr.push(root.formattedArtists);
-        if (titlePosition   == 1) arr.push(root.formattedTitle);
-        if (albumPosition   == 1) arr.push(root.formattedAlbum);
+        if (artistsPosition == 1) arr.push(root.artists);
+        if (titlePosition   == 1) arr.push(root.title);
+        if (albumPosition   == 1) arr.push(root.album);
 
         return arr;
     }
@@ -47,9 +42,9 @@ ColumnLayout {
     property var secondLineArray: {
         const arr = [];
 
-        if (artistsPosition == 2) arr.push(root.formattedArtists);
-        if (titlePosition   == 2) arr.push(root.formattedTitle);
-        if (albumPosition   == 2) arr.push(root.formattedAlbum);
+        if (artistsPosition == 2) arr.push(root.artists);
+        if (titlePosition   == 2) arr.push(root.title);
+        if (albumPosition   == 2) arr.push(root.album);
 
         return arr;        
     }
@@ -61,9 +56,9 @@ ColumnLayout {
     property var thirdLineArray: {
         const arr = [];
 
-        if (artistsPosition == 3) arr.push(root.formattedArtists);
-        if (titlePosition   == 3) arr.push(root.formattedTitle);
-        if (albumPosition   == 3) arr.push(root.formattedAlbum);
+        if (artistsPosition == 3) arr.push(root.artists);
+        if (titlePosition   == 3) arr.push(root.title);
+        if (albumPosition   == 3) arr.push(root.album);
 
         return arr;   
     }
@@ -75,7 +70,7 @@ ColumnLayout {
         // visible only when necessary
         visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour
-        font: root.textFont
+        font: root.boldTextFont
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
 

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -57,6 +57,19 @@ ColumnLayout {
     property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
     property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
 
+    // ONLY USED FOR FULL.qml
+    property var thirdLineArray: {
+        const arr = [];
+
+        if (artistsPosition == 3) arr.push(root.formattedArtists);
+        if (titlePosition   == 3) arr.push(root.formattedTitle);
+        if (albumPosition   == 3) arr.push(root.formattedAlbum);
+
+        return arr;   
+    }
+
+    property string finalThirdText: thirdLineArray.filter((x) => x).join(" - ")
+
     // first row of text (the only row, if there is only one)
     ScrollingText {
         // visible only when necessary
@@ -85,6 +98,23 @@ ColumnLayout {
         maxWidth: root.maxWidth
 
         text: root.finalSecondText
+        
+        scrollingEnabled: root.scrollingEnabled
+        scrollResetOnPause: root.scrollingResetOnPause
+        textColor: root.color
+        forcePauseScrolling: root.forcePauseScrolling
+        Layout.alignment: root.textAlignment
+    }
+
+    ScrollingText {
+        // visible only when necessary
+        visible: text.length !== 0
+        overflowBehaviour: root.scrollingBehaviour
+        font: root.textFont
+        speed: root.scrollingSpeed
+        maxWidth: root.maxWidth
+
+        text: root.finalThirdText
         
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -20,7 +20,6 @@ ColumnLayout {
     property var scrollingEnabled: undefined
     property var forcePauseScrolling: undefined
 
-    // 0 is hidden, 1 is first line, 2 is second line
 
     property int titlePosition: SongAndArtistText.TextPosition.FirstLine
     property int artistsPosition: SongAndArtistText.TextPosition.FirstLine

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -75,7 +75,7 @@ ColumnLayout {
         // visible only when necessary
         visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour
-        font: root.boldTextFont
+        font: finalSecondText.length > 0 ? root.boldTextFont : root.textFont;
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
 

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -13,22 +13,84 @@ ColumnLayout {
     property var scrollingEnabled: undefined
     property var forcePauseScrolling: undefined
     property bool splitSongAndArtists: false
+    property bool showAlbumTitle: true
+    property bool albumBeneathSongAndArtists: true
+
     property font textFont: Kirigami.Theme.defaultFont
     property font boldTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
+    property font italicTextFont: Qt.font(Object.assign({}, textFont, {italic: true}))
     property string color: Kirigami.Theme.textColor
     property string title
     property string artists
+    property string album
     property int textAlignment: Qt.AlignHCenter
 
     spacing: 0
 
+    // [root.artists, root.title].filter((x) => x).join(" - ")
+
+    property string formattedTitle: `<b>${root.title}</b>`
+    property string formattedArtists: `${root.artists}`
+    property string formattedAlbum: `<i>${root.album}</i>`
+
+    property string finalFirstText: {
+        if (root.showAlbumTitle) {
+            if (root.albumBeneathSongAndArtists) {
+                if (splitSongAndArtists) {
+                    return formattedTitle
+                } else {
+                    return [formattedArtists,formattedTitle].filter((x) => x).join(" - ")
+                }
+            } else {
+                if (splitSongAndArtists) {
+                    return [formattedTitle,formattedAlbum].filter((x) => x).join(" - ")
+                } else {
+                    return [formattedArtists,formattedTitle,formattedAlbum].filter((x) => x).join(" - ")
+                }
+            }
+        } else {
+            if (root.splitSongAndArtists) {
+                return formattedTitle
+            } else {
+                return [formattedArtists,formattedTitle].filter((x) => x).join(" - ")
+            }
+        }
+    }
+
+    property string finalSecondText: {
+        if (root.showAlbumTitle) {
+            if (root.albumBeneathSongAndArtists) {
+                if (splitSongAndArtists) {
+                    return [formattedArtists,formattedAlbum].filter((x) => x).join(" - ")
+                } else {
+                    return formattedAlbum
+                }
+            } else {
+                if (splitSongAndArtists) {
+                    return formattedArtists
+                } else {
+                    return ""
+                }
+            }
+        } else {
+            if (root.splitSongAndArtists) {
+                return formattedArtists
+            } else {
+                return ""
+            }
+        }
+    }
+
+    // first row of text (the only row, if there is only one)
     ScrollingText {
-        visible: root.splitSongAndArtists
+        // always visible
         overflowBehaviour: root.scrollingBehaviour
-        font: root.boldTextFont
+        font: root.textFont
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
-        text: root.title
+
+        text: root.finalFirstText
+
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause
         textColor: root.color
@@ -36,17 +98,51 @@ ColumnLayout {
         Layout.alignment: root.textAlignment
     }
 
+    // second row of text
     ScrollingText {
+        // visible only when necessary
+        visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour
         font: root.textFont
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
-        text: root.splitSongAndArtists ? root.artists : [root.artists, root.title].filter((x) => x).join(" - ")
+
+        text: root.finalSecondText
+        
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause
-        visible: text.length !== 0
         textColor: root.color
         forcePauseScrolling: root.forcePauseScrolling
         Layout.alignment: root.textAlignment
     }
+
+    // // top text
+    // ScrollingText {
+    //     visible: root.splitSongAndArtists
+    //     overflowBehaviour: root.scrollingBehaviour
+    //     font: root.boldTextFont
+    //     speed: root.scrollingSpeed
+    //     maxWidth: root.maxWidth
+    //     text: root.title
+    //     scrollingEnabled: root.scrollingEnabled
+    //     scrollResetOnPause: root.scrollingResetOnPause
+    //     textColor: root.color
+    //     forcePauseScrolling: root.forcePauseScrolling
+    //     Layout.alignment: root.textAlignment
+    // }
+
+    // // second row of text
+    // ScrollingText {
+    //     overflowBehaviour: root.scrollingBehaviour
+    //     font: root.textFont
+    //     speed: root.scrollingSpeed
+    //     maxWidth: root.maxWidth
+    //     text: root.splitSongAndArtists ? root.artists : [root.artists, root.title].filter((x) => x).join(" - ")
+    //     scrollingEnabled: root.scrollingEnabled
+    //     scrollResetOnPause: root.scrollingResetOnPause
+    //     visible: text.length !== 0
+    //     textColor: root.color
+    //     forcePauseScrolling: root.forcePauseScrolling
+    //     Layout.alignment: root.textAlignment
+    // }
 }

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -229,7 +229,7 @@ KCM.SimpleKCM {
         }
 
         RadioButton {
-            Kirigami.FormData.label: i18n("Artist names position:")
+            Kirigami.FormData.label: i18n("Artists position:")
             text: i18n("Hidden")
             checked: artistsPosition.value == 0
             onCheckedChanged: () => {

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -24,7 +24,6 @@ KCM.SimpleKCM {
     property alias cfg_songTextFixedWidth: songTextFixedWidth.value
     property alias cfg_useSongTextFixedWidth: useSongTextFixedWidth.checked
     property alias cfg_textScrollingSpeed: textScrollingSpeed.value
-    property alias cfg_separateText: separateText.checked
     property alias cfg_textScrollingBehaviour: scrollingBehaviourRadio.value
     property alias cfg_pauseTextScrollingWhileMediaIsNotPlaying: pauseWhileMediaIsNotPlaying.checked
     property alias cfg_textScrollingEnabled: textScrollingEnabledCheckbox.checked
@@ -35,8 +34,9 @@ KCM.SimpleKCM {
     property alias cfg_songTextAlignment: songTextPositionRadio.value
     property alias cfg_panelIconSizeRatio: panelIconSizeRatio.value
     property alias cfg_panelControlsSizeRatio: panelControlsSizeRatio.value
-    property alias cfg_showAlbumTitle: showAlbumTitle.checked
-    property alias cfg_albumBeneathSongAndArtists: albumBeneathSongAndArtists.checked
+    property alias cfg_artistsPosition: artistsPosition.value
+    property alias cfg_titlePosition: titlePosition.value
+    property alias cfg_albumPosition: albumPosition.value
 
     Kirigami.FormLayout {
         id: form
@@ -129,17 +129,6 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Show skip forward control:")
         }
 
-        CheckBox {
-            id: showAlbumTitle
-            Kirigami.FormData.label: i18n("Show album title:")
-        }
-
-        CheckBox {
-            id: albumBeneathSongAndArtists
-            Kirigami.FormData.label: i18n("Show album title below song and artists:")
-            enabled: showAlbumTitle.checked
-        }
-
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Kirigami.FormData.label: i18n("Icon customization")
@@ -185,10 +174,142 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Song text customization")
         }
 
+        // group for title
 
-        CheckBox {
-            id: separateText
-            Kirigami.FormData.label: i18n("Title and artist in separate lines")
+        ButtonGroup {
+            id: titlePosition
+            property int value: 1
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Song title position:")
+            text: i18n("Hidden")
+            checked: titlePosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    titlePosition.value = 0
+                }
+            }
+            ButtonGroup.group: titlePosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: titlePosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    titlePosition.value = 1
+                }
+            }
+            ButtonGroup.group: titlePosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: titlePosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    titlePosition.value = 2
+                }
+            }
+            ButtonGroup.group: titlePosition
+        }
+
+
+        // group for artists
+
+        Item {
+            // adds spacing between the groups
+            height: 0.5 * Kirigami.Units.gridUnit
+        }
+
+        ButtonGroup {
+            id: artistsPosition
+            property int value: 1
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Artist names position:")
+            text: i18n("Hidden")
+            checked: artistsPosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    artistsPosition.value = 0
+                }
+            }
+            ButtonGroup.group: artistsPosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: artistsPosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    artistsPosition.value = 1
+                }
+            }
+            ButtonGroup.group: artistsPosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: artistsPosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    artistsPosition.value = 2
+                }
+            }
+            ButtonGroup.group: artistsPosition
+        }
+
+        // group for album
+        Item {
+            // adds spacing between the groups
+            height: 0.5 * Kirigami.Units.gridUnit
+        }
+
+        ButtonGroup {
+            id: albumPosition
+            property int value: 0
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Album title position:")
+            text: i18n("Hidden")
+            checked: albumPosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    albumPosition.value = 0
+                }
+            }
+            ButtonGroup.group: albumPosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: albumPosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    albumPosition.value = 1
+                }
+            }
+            ButtonGroup.group: albumPosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: albumPosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    albumPosition.value = 2
+                }
+            }
+            ButtonGroup.group: albumPosition
+        }
+
+        Item {
+            // adds spacing between the groups
+            height: 0.5 * Kirigami.Units.gridUnit
         }
 
         CheckBox {

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -178,16 +178,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: titlePosition
-            property int value: 1
+            property int value: SongAndArtistText.TextPosition.FirstLine
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Song title position:")
             text: i18n("Hidden")
-            checked: titlePosition.value == 0
+            checked: titlePosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    titlePosition.value = 0
+                    titlePosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: titlePosition
@@ -195,10 +195,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: titlePosition.value == 1
+            checked: titlePosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    titlePosition.value = 1
+                    titlePosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: titlePosition
@@ -206,10 +206,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: titlePosition.value == 2
+            checked: titlePosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    titlePosition.value = 2
+                    titlePosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: titlePosition
@@ -225,16 +225,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: artistsPosition
-            property int value: 1
+            property int value: SongAndArtistText.TextPosition.FirstLine
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Artists position:")
             text: i18n("Hidden")
-            checked: artistsPosition.value == 0
+            checked: artistsPosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    artistsPosition.value = 0
+                    artistsPosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: artistsPosition
@@ -242,10 +242,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: artistsPosition.value == 1
+            checked: artistsPosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    artistsPosition.value = 1
+                    artistsPosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: artistsPosition
@@ -253,10 +253,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: artistsPosition.value == 2
+            checked: artistsPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    artistsPosition.value = 2
+                    artistsPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: artistsPosition
@@ -270,16 +270,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: albumPosition
-            property int value: 0
+            property int value: SongAndArtistText.TextPosition.Hidden
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Album title position:")
             text: i18n("Hidden")
-            checked: albumPosition.value == 0
+            checked: albumPosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    albumPosition.value = 0
+                    albumPosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: albumPosition
@@ -287,10 +287,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: albumPosition.value == 1
+            checked: albumPosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    albumPosition.value = 1
+                    albumPosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: albumPosition
@@ -298,10 +298,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: albumPosition.value == 2
+            checked: albumPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    albumPosition.value = 2
+                    albumPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: albumPosition

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -35,6 +35,8 @@ KCM.SimpleKCM {
     property alias cfg_songTextAlignment: songTextPositionRadio.value
     property alias cfg_panelIconSizeRatio: panelIconSizeRatio.value
     property alias cfg_panelControlsSizeRatio: panelControlsSizeRatio.value
+    property alias cfg_showAlbumTitle: showAlbumTitle.checked
+    property alias cfg_albumBeneathSongAndArtists: albumBeneathSongAndArtists.checked
 
     Kirigami.FormLayout {
         id: form
@@ -125,6 +127,17 @@ KCM.SimpleKCM {
         CheckBox {
             id: skipForwardControlInPanel
             Kirigami.FormData.label: i18n("Show skip forward control:")
+        }
+
+        CheckBox {
+            id: showAlbumTitle
+            Kirigami.FormData.label: i18n("Show album title:")
+        }
+
+        CheckBox {
+            id: albumBeneathSongAndArtists
+            Kirigami.FormData.label: i18n("Show album title below song and artists:")
+            enabled: showAlbumTitle.checked
         }
 
         Kirigami.Separator {

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -14,6 +14,9 @@ KCM.SimpleKCM {
     property alias cfg_desktopWidgetBg: desktopWidgetBackgroundRadio.value
     property alias cfg_albumPlaceholder: albumPlaceholderDialog.value
     property alias cfg_fullViewTextScrollingSpeed: fullViewTextScrollingSpeed.value
+    property alias cfg_fullArtistsPosition: fullArtistsPosition.value
+    property alias cfg_fullTitlePosition: fullTitlePosition.value
+    property alias cfg_fullAlbumPosition: fullAlbumPosition.value
 
     Kirigami.FormLayout {
         id: form
@@ -44,6 +47,177 @@ KCM.SimpleKCM {
                 Layout.alignment: Qt.AlignHCenter
                 source: albumPlaceholderDialog.value
             }
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Song Text Customization")
+        }
+
+        // group for title
+
+        ButtonGroup {
+            id: fullTitlePosition
+            property int value: 1
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Song title position:")
+            text: i18n("Hidden")
+            checked: fullTitlePosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullTitlePosition.value = 0
+                }
+            }
+            ButtonGroup.group: fullTitlePosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: fullTitlePosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullTitlePosition.value = 1
+                }
+            }
+            ButtonGroup.group: fullTitlePosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: fullTitlePosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullTitlePosition.value = 2
+                }
+            }
+            ButtonGroup.group: fullTitlePosition
+        }
+
+        RadioButton {
+            text: i18n("Third line")
+            checked: fullTitlePosition.value == 3
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullTitlePosition.value = 3
+                }
+            }
+            ButtonGroup.group: fullTitlePosition
+        }
+
+
+        // group for artists
+
+        Item {
+            // adds spacing between the groups
+            height: 0.5 * Kirigami.Units.gridUnit
+        }
+
+        ButtonGroup {
+            id: fullArtistsPosition
+            property int value: 2
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Artists position:")
+            text: i18n("Hidden")
+            checked: fullArtistsPosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullArtistsPosition.value = 0
+                }
+            }
+            ButtonGroup.group: fullArtistsPosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: fullArtistsPosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullArtistsPosition.value = 1
+                }
+            }
+            ButtonGroup.group: fullArtistsPosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: fullArtistsPosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullArtistsPosition.value = 2
+                }
+            }
+            ButtonGroup.group: fullArtistsPosition
+        }
+
+        RadioButton {
+            text: i18n("Third line")
+            checked: fullArtistsPosition.value == 3
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullArtistsPosition.value = 3
+                }
+            }
+            ButtonGroup.group: fullArtistsPosition
+        }
+
+        // group for album
+        Item {
+            // adds spacing between the groups
+            height: 0.5 * Kirigami.Units.gridUnit
+        }
+
+        ButtonGroup {
+            id: fullAlbumPosition
+            property int value: 3
+        }
+
+        RadioButton {
+            Kirigami.FormData.label: i18n("Album title position:")
+            text: i18n("Hidden")
+            checked: fullAlbumPosition.value == 0
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullAlbumPosition.value = 0
+                }
+            }
+            ButtonGroup.group: fullAlbumPosition
+        }
+
+        RadioButton {
+            text: i18n("First line")
+            checked: fullAlbumPosition.value == 1
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullAlbumPosition.value = 1
+                }
+            }
+            ButtonGroup.group: fullAlbumPosition
+        }
+
+        RadioButton {
+            text: i18n("Second line")
+            checked: fullAlbumPosition.value == 2
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullAlbumPosition.value = 2
+                }
+            }
+            ButtonGroup.group: fullAlbumPosition
+        }
+
+        RadioButton {
+            text: i18n("Third line")
+            checked: fullAlbumPosition.value == 3
+            onCheckedChanged: () => {
+                if (checked) {
+                    fullAlbumPosition.value = 3
+                }
+            }
+            ButtonGroup.group: fullAlbumPosition
         }
 
         Kirigami.Separator {

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -1,3 +1,4 @@
+import "../components"
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
@@ -58,16 +59,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: fullTitlePosition
-            property int value: 1
+            property int value: SongAndArtistText.TextPosition.FirstLine
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Song title position:")
             text: i18n("Hidden")
-            checked: fullTitlePosition.value == 0
+            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    fullTitlePosition.value = 0
+                    fullTitlePosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: fullTitlePosition
@@ -75,10 +76,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: fullTitlePosition.value == 1
+            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullTitlePosition.value = 1
+                    fullTitlePosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: fullTitlePosition
@@ -86,10 +87,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: fullTitlePosition.value == 2
+            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullTitlePosition.value = 2
+                    fullTitlePosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullTitlePosition
@@ -97,10 +98,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullTitlePosition.value == 3
+            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.ThirdLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullTitlePosition.value = 3
+                    fullTitlePosition.value = SongAndArtistText.TextPosition.ThirdLine
                 }
             }
             ButtonGroup.group: fullTitlePosition
@@ -116,16 +117,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: fullArtistsPosition
-            property int value: 2
+            property int value: SongAndArtistText.TextPosition.SecondLine
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Artists position:")
             text: i18n("Hidden")
-            checked: fullArtistsPosition.value == 0
+            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    fullArtistsPosition.value = 0
+                    fullArtistsPosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: fullArtistsPosition
@@ -133,10 +134,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: fullArtistsPosition.value == 1
+            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullArtistsPosition.value = 1
+                    fullArtistsPosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: fullArtistsPosition
@@ -144,10 +145,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: fullArtistsPosition.value == 2
+            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullArtistsPosition.value = 2
+                    fullArtistsPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullArtistsPosition
@@ -155,10 +156,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullArtistsPosition.value == 3
+            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.ThirdLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullArtistsPosition.value = 3
+                    fullArtistsPosition.value = SongAndArtistText.TextPosition.ThirdLine
                 }
             }
             ButtonGroup.group: fullArtistsPosition
@@ -172,16 +173,16 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: fullAlbumPosition
-            property int value: 3
+            property int value: SongAndArtistText.TextPosition.ThirdLine
         }
 
         RadioButton {
             Kirigami.FormData.label: i18n("Album title position:")
             text: i18n("Hidden")
-            checked: fullAlbumPosition.value == 0
+            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.Hidden
             onCheckedChanged: () => {
                 if (checked) {
-                    fullAlbumPosition.value = 0
+                    fullAlbumPosition.value = SongAndArtistText.TextPosition.Hidden
                 }
             }
             ButtonGroup.group: fullAlbumPosition
@@ -189,10 +190,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("First line")
-            checked: fullAlbumPosition.value == 1
+            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.FirstLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullAlbumPosition.value = 1
+                    fullAlbumPosition.value = SongAndArtistText.TextPosition.FirstLine
                 }
             }
             ButtonGroup.group: fullAlbumPosition
@@ -200,10 +201,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Second line")
-            checked: fullAlbumPosition.value == 2
+            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullAlbumPosition.value = 2
+                    fullAlbumPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullAlbumPosition
@@ -211,10 +212,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullAlbumPosition.value == 3
+            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.ThirdLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullAlbumPosition.value = 3
+                    fullAlbumPosition.value = SongAndArtistText.TextPosition.ThirdLine
                 }
             }
             ButtonGroup.group: fullAlbumPosition

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -98,10 +98,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.ThirdLine
+            checked: fullTitlePosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullTitlePosition.value = SongAndArtistText.TextPosition.ThirdLine
+                    fullTitlePosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullTitlePosition
@@ -156,10 +156,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.ThirdLine
+            checked: fullArtistsPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullArtistsPosition.value = SongAndArtistText.TextPosition.ThirdLine
+                    fullArtistsPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullArtistsPosition
@@ -173,7 +173,7 @@ KCM.SimpleKCM {
 
         ButtonGroup {
             id: fullAlbumPosition
-            property int value: SongAndArtistText.TextPosition.ThirdLine
+            property int value: SongAndArtistText.TextPosition.SecondLine
         }
 
         RadioButton {
@@ -212,10 +212,10 @@ KCM.SimpleKCM {
 
         RadioButton {
             text: i18n("Third line")
-            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.ThirdLine
+            checked: fullAlbumPosition.value == SongAndArtistText.TextPosition.SecondLine
             onCheckedChanged: () => {
                 if (checked) {
-                    fullAlbumPosition.value = SongAndArtistText.TextPosition.ThirdLine
+                    fullAlbumPosition.value = SongAndArtistText.TextPosition.SecondLine
                 }
             }
             ButtonGroup.group: fullAlbumPosition

--- a/src/contents/ui/config/General.qml
+++ b/src/contents/ui/config/General.qml
@@ -16,9 +16,6 @@ KCM.SimpleKCM {
     property alias cfg_customFont: fontDialog.fontChosen
     property alias cfg_volumeStep: volumeStepSpinbox.value
 
-    property alias cfg_italiciseAlbumTitle: italiciseAlbumTitle.checked
-    property alias cfg_boldSongTitle: boldSongTitle.checked
-
     Kirigami.FormLayout {
         id: form
 
@@ -111,16 +108,6 @@ KCM.SimpleKCM {
                     fontDialog.open()
                 }
             }
-        }
-
-        CheckBox {
-            id: italiciseAlbumTitle
-            Kirigami.FormData.label: i18n("Italicise album title:")
-        }
-
-        CheckBox {
-            id: boldSongTitle
-            Kirigami.FormData.label: i18n("Bold song title:")
         }
 
         Label {

--- a/src/contents/ui/config/General.qml
+++ b/src/contents/ui/config/General.qml
@@ -16,6 +16,9 @@ KCM.SimpleKCM {
     property alias cfg_customFont: fontDialog.fontChosen
     property alias cfg_volumeStep: volumeStepSpinbox.value
 
+    property alias cfg_italiciseAlbumTitle: italiciseAlbumTitle.checked
+    property alias cfg_boldSongTitle: boldSongTitle.checked
+
     Kirigami.FormLayout {
         id: form
 
@@ -108,6 +111,16 @@ KCM.SimpleKCM {
                     fontDialog.open()
                 }
             }
+        }
+
+        CheckBox {
+            id: italiciseAlbumTitle
+            Kirigami.FormData.label: i18n("Italicise album title:")
+        }
+
+        CheckBox {
+            id: boldSongTitle
+            Kirigami.FormData.label: i18n("Bold song title:")
         }
 
         Label {


### PR DESCRIPTION
It now has two new options
- show album title
- show album title below song title and artists

I also updated the logic for SongAndArtistsText.qml to make it easier to create logic for how to organize all of the text, depending on what options are selected in the configuration.

I also added html tags to bold and italicise the song title and album title, respectively. These each have their own option in the configuration as well.

(https://github.com/ccatterina/plasmusic-toolbar/issues/168)