### PR TITLE
feat!: remove commandsInPanel option

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -24,9 +24,6 @@
         <entry name="maxSongWidthInPanel" type="Int">
             <default>200</default>
         </entry>
-        <entry name="commandsInPanel" type="Bool">
-            <default>true</default>
-        </entry>
         <entry name="skipBackwardControlInPanel" type="Bool">
             <default>true</default>
         </entry>

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -205,8 +205,6 @@ Item {
         }
 
         GridLayout {
-            visible: plasmoid.configuration.commandsInPanel
-
             columns: horizontal ? grid.children.length : 1
             rows: horizontal ? 1 : grid.children.length
 

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -14,7 +14,6 @@ KCM.SimpleKCM {
     property alias cfg_useAlbumCoverAsPanelIcon: useAlbumCoverAsPanelIcon.checked
     property alias cfg_fallbackToIconWhenArtNotAvailable: fallbackToIconWhenArtNotAvailable.checked
     property alias cfg_albumCoverRadius: albumCoverRadius.value
-    property alias cfg_commandsInPanel: commandsInPanel.checked
     property alias cfg_skipBackwardControlInPanel: skipBackwardControlInPanel.checked
     property alias cfg_playPauseControlInPanel: playPauseControlInPanel.checked
     property alias cfg_skipForwardControlInPanel: skipForwardControlInPanel.checked
@@ -105,11 +104,6 @@ KCM.SimpleKCM {
         CheckBox {
             id: songTextInPanel
             Kirigami.FormData.label: i18n("Show song text:")
-        }
-
-        CheckBox {
-            id: commandsInPanel
-            Kirigami.FormData.label: i18n("Show playback controls (⚠ deprecated):")
         }
 
         CheckBox {


### PR DESCRIPTION
It has been replaced by options to show/hide specific commands (e.g. skipBackwardControlInPanel) and deprecated in the previous releases.