### PR TITLE
fix: resolve TrackPositionSlider always being disabled

### DIFF
--- a/src/contents/ui/components/TrackPositionSlider.qml
+++ b/src/contents/ui/components/TrackPositionSlider.qml
@@ -57,14 +57,18 @@ Item {
                 changingPosition = false
             }
 
-            MouseArea {
-                id: sliderDisabler
-                enabled: conainer.songLength <= 0
-
+            // Disable the slider events when songLength is 0 or less
+            Loader {
                 anchors.fill: parent
-                onWheel: (wheel) => { wheel.accepted = true }
-                onClicked: (mouse) => { mouse.accepted = true }
-                onPressed: (mouse) => { mouse.accepted = true }
+                sourceComponent: container.songLength <= 0 ? sliderDisabler : null
+                Component {
+                    id: sliderDisabler
+                    MouseArea {
+                        onWheel: (wheel) => { wheel.accepted = true }
+                        onClicked: (mouse) => { mouse.accepted = true }
+                        onPressed: (mouse) => { mouse.accepted = true }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
The MouseArea added in 381117e0af to block mouse/wheel events when songLength ≤ 0 was intercepting events even when disabled, making the slider completely non-functional.

Solution: Use a Loader to create MouseArea only when needed.