### PR TITLE
Make an option for the widget to be always visible

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -114,5 +114,11 @@
         <entry name="fullAlbumPosition" type="Int">
             <default>2</default>
         </entry>
+        <entry name="noMediaText" type="String">
+            <default>No media playing</default>
+        </entry>
+        <entry name="showWhenNoMedia" type="Bool">
+            <default>False</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -115,7 +115,7 @@
             <default>2</default>
         </entry>
         <entry name="noMediaText" type="String">
-            <default>No media playing</default>
+            <default>No media found</default>
         </entry>
         <entry name="showWhenNoMedia" type="Bool">
             <default>False</default>

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -19,6 +19,7 @@ ColumnLayout {
     property var scrollingEnabled: undefined
     property var forcePauseScrolling: undefined
 
+    property string noMediaText: plasmoid.configuration.noMediaText
 
     property int titlePosition: SongAndArtistText.TextPosition.FirstLine
     property int artistsPosition: SongAndArtistText.TextPosition.FirstLine
@@ -67,7 +68,7 @@ ColumnLayout {
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
 
-        text: root.finalFirstText
+        text: root.finalFirstText && root.finalSecondText ? root.finalFirstText : noMediaText
 
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -68,7 +68,7 @@ ColumnLayout {
         speed: root.scrollingSpeed
         maxWidth: root.maxWidth
 
-        text: root.finalFirstText && root.finalSecondText ? root.finalFirstText : noMediaText
+        text: root.finalFirstText || root.finalSecondText ? root.finalFirstText : noMediaText
 
         scrollingEnabled: root.scrollingEnabled
         scrollResetOnPause: root.scrollingResetOnPause

--- a/src/contents/ui/config/General.qml
+++ b/src/contents/ui/config/General.qml
@@ -15,6 +15,8 @@ KCM.SimpleKCM {
     property alias cfg_useCustomFont: customFontCheckbox.checked
     property alias cfg_customFont: fontDialog.fontChosen
     property alias cfg_volumeStep: volumeStepSpinbox.value
+    property alias cfg_noMediaText: noMediaText.text
+    property alias cfg_showWhenNoMedia: showWhenNoMedia.checked
 
     Kirigami.FormLayout {
         id: form
@@ -115,6 +117,22 @@ KCM.SimpleKCM {
             text: i18n("%1pt %2", fontDialog.fontChosen.pointSize, fontDialog.fontChosen.family)
             textFormat: Text.PlainText
             font: fontDialog.fontChosen
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("No media playing")
+        }
+
+        CheckBox {
+            id:showWhenNoMedia
+            Kirigami.FormData.label: i18n("Show widget when no media playing:")
+        }
+
+        TextField {
+            id: noMediaText
+            Kirigami.FormData.label: i18n("Text displayed when no media playing:")
+            enabled: showWhenNoMedia.checked
         }
 
         Kirigami.Separator {

--- a/src/contents/ui/config/General.qml
+++ b/src/contents/ui/config/General.qml
@@ -121,17 +121,17 @@ KCM.SimpleKCM {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("No media playing")
+            Kirigami.FormData.label: i18n("No media found behavior")
         }
 
         CheckBox {
             id:showWhenNoMedia
-            Kirigami.FormData.label: i18n("Show widget when no media playing:")
+            Kirigami.FormData.label: i18n("Show widget when no media found:")
         }
 
         TextField {
             id: noMediaText
-            Kirigami.FormData.label: i18n("Text displayed when no media playing:")
+            Kirigami.FormData.label: i18n("Text displayed when no media found:")
             enabled: showWhenNoMedia.checked
         }
 

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,11 +10,12 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: PlasmaCore.Types.HiddenStatus
+    Plasmoid.status: showWhenNoMedia ? PlasmaCore.Types.ActiveStatus : player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
     readonly property int location: Plasmoid.location
+    readonly property bool showWhenNoMedia: plasmoid.configuration.showWhenNoMedia
 
     readonly property font baseFont: plasmoid.configuration.useCustomFont ? plasmoid.configuration.customFont : Kirigami.Theme.defaultFont
 
@@ -29,6 +30,10 @@ PlasmoidItem {
         return text
     }
 
+    onShowWhenNoMediaChanged: {
+        Plasmoid.status = showWhenNoMedia ? PlasmaCore.Types.ActiveStatus : player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+    }
+
     Player {
         id: player
         sourceIdentity: {
@@ -37,9 +42,10 @@ PlasmoidItem {
             }
         }
         onReadyChanged: {
-          Plasmoid.status = player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-          console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+            Plasmoid.status = showWhenNoMedia ? PlasmaCore.Types.ActiveStatus : player.ready ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus;
+            console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
         }
+
     }
 
     compactRepresentation: Compact {}


### PR DESCRIPTION
This solves #143.

It keeps the toolbar widget always open, regardless of whether or not media is playing.
It also adds two new options:
- Show widget when no media playing (checkbox)
- Text displayed when no media playing (text field)

The second allows the customizable text mentioned in #143.