### PR TITLE
feat: use album cover as background in full view

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -114,6 +114,9 @@
         <entry name="fullAlbumPosition" type="Int">
             <default>2</default>
         </entry>
+        <entry name="fullAlbumCoverAsBackground" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="noMediaText" type="String">
             <default>No media found</default>
         </entry>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -34,7 +34,7 @@ Item {
 
         Rectangle {
             Layout.alignment: Qt.AlignHCenter
-            Layout.margins: plasmoid.configuration.fullAlbumCoverAsBackground ? 0 : 10
+            Layout.margins: useImageColors ? 0 : 10
             width: 300
             height: width
             color: 'transparent'

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -18,8 +18,6 @@ Item {
     Layout.preferredWidth: column.implicitWidth
     Layout.minimumWidth: column.implicitWidth
     Layout.minimumHeight: column.implicitHeight
-    Layout.maximumWidth: column.implicitWidth
-    Layout.maximumHeight: column.implicitHeight
 
 
     Kirigami.Theme.textColor: albumCoverBackground ? imageColors.fgColor : Kirigami.Theme.textColor

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -18,6 +18,7 @@ KCM.SimpleKCM {
     property alias cfg_fullArtistsPosition: fullArtistsPosition.value
     property alias cfg_fullTitlePosition: fullTitlePosition.value
     property alias cfg_fullAlbumPosition: fullAlbumPosition.value
+    property alias cfg_fullAlbumCoverAsBackground: fullAlbumCoverAsBackground.checked
 
     Kirigami.FormLayout {
         id: form
@@ -213,7 +214,7 @@ KCM.SimpleKCM {
 
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
-            Kirigami.FormData.label: i18n("Background (desktop widget only)")
+            Kirigami.FormData.label: i18n("Background")
         }
 
         ButtonGroup {
@@ -222,6 +223,7 @@ KCM.SimpleKCM {
         }
 
         RowLayout {
+            Kirigami.FormData.label: i18n("Background (desktop widget only):")
             RadioButton {
                 text: i18n("Standard")
                 checked: desktopWidgetBackgroundRadio.value == PlasmaCore.Types.StandardBackground
@@ -264,6 +266,12 @@ KCM.SimpleKCM {
                     "The applet won't have a background but a drop shadow of its content done via a shader. The text color will also invert."
                 )
             }
+        }
+
+        CheckBox {
+            Kirigami.FormData.label: i18n("Use album cover as background:")
+            id: fullAlbumCoverAsBackground
+            text: i18n("(Experimental feature)")
         }
     }
 

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 23:27-0400\n"
+"POT-Creation-Date: 2025-08-28 18:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,12 +32,12 @@ msgstr "Vista pannello"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:55
+#: src/contents/ui/Full.qml:97
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:55 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"
@@ -147,41 +147,41 @@ msgstr "Arrotondamento bordo copertina album:"
 msgid "Song text customization"
 msgstr "Personalizzazione testo brano"
 
-#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Song title position:"
 msgstr "Posizionamento titolo:"
 
 #: src/contents/ui/config/Compact.qml:178
 #: src/contents/ui/config/Compact.qml:225
-#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:76
-#: src/contents/ui/config/Full.qml:123 src/contents/ui/config/Full.qml:168
+#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:77
+#: src/contents/ui/config/Full.qml:124 src/contents/ui/config/Full.qml:169
 #, kde-format
 msgid "Hidden"
 msgstr "Nascosto"
 
 #: src/contents/ui/config/Compact.qml:189
 #: src/contents/ui/config/Compact.qml:236
-#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:87
-#: src/contents/ui/config/Full.qml:134 src/contents/ui/config/Full.qml:179
+#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:88
+#: src/contents/ui/config/Full.qml:135 src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "First line"
 msgstr "Prima riga"
 
 #: src/contents/ui/config/Compact.qml:200
 #: src/contents/ui/config/Compact.qml:247
-#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:98
-#: src/contents/ui/config/Full.qml:145 src/contents/ui/config/Full.qml:190
+#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:99
+#: src/contents/ui/config/Full.qml:146 src/contents/ui/config/Full.qml:191
 #, kde-format
 msgid "Second line"
 msgstr "Seconda riga"
 
-#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Artists position:"
 msgstr "Posizione artista/i:"
 
-#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:168
 #, kde-format
 msgid "Album title position:"
 msgstr "Posizione titolo album:"
@@ -201,7 +201,7 @@ msgstr "larghezza fissa:"
 msgid "max width:"
 msgstr "larghezza massima:"
 
-#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Text scrolling"
 msgstr "Scorrimento testo"
@@ -211,7 +211,7 @@ msgstr "Scorrimento testo"
 msgid "Enabled:"
 msgstr "Abilitato:"
 
-#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:211
+#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:212
 #, kde-format
 msgid "Speed:"
 msgstr "Velocità:"
@@ -251,7 +251,7 @@ msgstr "Reimposta posizione quando lo scorrimento è in pausa:"
 msgid "Playback controls customization"
 msgstr "Personalizzazione comandi di riproduzione"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:421 src/contents/ui/config/Full.qml:217
 #, kde-format
 msgid "Background"
 msgstr "Sfondo"
@@ -285,50 +285,60 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Resetta icona"
 
-#: src/contents/ui/config/Full.qml:27
+#: src/contents/ui/config/Full.qml:28
 #, kde-format
 msgid "Album cover"
 msgstr "Copertina album"
 
-#: src/contents/ui/config/Full.qml:31
+#: src/contents/ui/config/Full.qml:32
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Immagine placeholder per album:"
 
-#: src/contents/ui/config/Full.qml:34 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:35 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Scegli…"
 
-#: src/contents/ui/config/Full.qml:42
+#: src/contents/ui/config/Full.qml:43
 #, fuzzy, kde-format
 msgid "Clear"
 msgstr "Resetta icona"
 
-#: src/contents/ui/config/Full.qml:64
+#: src/contents/ui/config/Full.qml:65
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personalizzazione testo canzone"
 
-#: src/contents/ui/config/Full.qml:216
-#, kde-format
-msgid "Background (desktop widget only)"
-msgstr "Sfondo (solo per widget desktop)"
-
 #: src/contents/ui/config/Full.qml:226
+#, kde-format
+msgid "Background (desktop widget only):"
+msgstr "Sfondo (solo per widget desktop):"
+
+#: src/contents/ui/config/Full.qml:228
 #, kde-format
 msgid "Standard"
 msgstr "Standard"
 
-#: src/contents/ui/config/Full.qml:242
+#: src/contents/ui/config/Full.qml:244
 #, kde-format
 msgid "Transparent"
 msgstr "Trasparente"
 
-#: src/contents/ui/config/Full.qml:253
+#: src/contents/ui/config/Full.qml:255
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Trasparente (Ombra)"
+
+#: src/contents/ui/config/Full.qml:272
+#, fuzzy, kde-format
+msgid "Use album cover as background:"
+msgstr "Usa copertina album come icona"
+
+#: src/contents/ui/config/Full.qml:274
+#, kde-format
+msgid "(Experimental feature)"
+msgstr ""
 
 #: src/contents/ui/config/General.qml:26
 #, kde-format

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-28 18:04+0200\n"
+"POT-Creation-Date: 2025-08-28 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,12 +32,12 @@ msgstr "Vista pannello"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:97
+#: src/contents/ui/Full.qml:95
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"
@@ -333,12 +333,12 @@ msgstr "Trasparente (Ombra)"
 #: src/contents/ui/config/Full.qml:272
 #, fuzzy, kde-format
 msgid "Use album cover as background:"
-msgstr "Usa copertina album come icona"
+msgstr "Usa copertina album come sfondo:"
 
 #: src/contents/ui/config/Full.qml:274
 #, kde-format
 msgid "(Experimental feature)"
-msgstr ""
+msgstr "Funzionalità sperimentale"
 
 #: src/contents/ui/config/General.qml:26
 #, kde-format

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 23:27-0400\n"
+"POT-Creation-Date: 2025-08-28 18:04+0200\n"
 "PO-Revision-Date: 2025-07-21 13:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -33,12 +33,12 @@ msgstr "Paneelweergave"
 msgid "Full View"
 msgstr "Volledige weergave"
 
-#: src/contents/ui/Full.qml:55
+#: src/contents/ui/Full.qml:97
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:55 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"
@@ -149,41 +149,41 @@ msgstr "Albumhoesafmetingen:"
 msgid "Song text customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Song title position:"
 msgstr "Tekstlocatie:"
 
 #: src/contents/ui/config/Compact.qml:178
 #: src/contents/ui/config/Compact.qml:225
-#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:76
-#: src/contents/ui/config/Full.qml:123 src/contents/ui/config/Full.qml:168
+#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:77
+#: src/contents/ui/config/Full.qml:124 src/contents/ui/config/Full.qml:169
 #, kde-format
 msgid "Hidden"
 msgstr "Verborgen"
 
 #: src/contents/ui/config/Compact.qml:189
 #: src/contents/ui/config/Compact.qml:236
-#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:87
-#: src/contents/ui/config/Full.qml:134 src/contents/ui/config/Full.qml:179
+#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:88
+#: src/contents/ui/config/Full.qml:135 src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "First line"
 msgstr "Eerste regel"
 
 #: src/contents/ui/config/Compact.qml:200
 #: src/contents/ui/config/Compact.qml:247
-#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:98
-#: src/contents/ui/config/Full.qml:145 src/contents/ui/config/Full.qml:190
+#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:99
+#: src/contents/ui/config/Full.qml:146 src/contents/ui/config/Full.qml:191
 #, kde-format
 msgid "Second line"
 msgstr "Tweede regel"
 
-#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Artists position:"
 msgstr "Artiestlocatie:"
 
-#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:168
 #, kde-format
 msgid "Album title position:"
 msgstr "Albumtitellocatie:"
@@ -203,7 +203,7 @@ msgstr "vaste breedte:"
 msgid "max width:"
 msgstr "max. breedte:"
 
-#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Text scrolling"
 msgstr "Tekst laten verschuiven"
@@ -213,7 +213,7 @@ msgstr "Tekst laten verschuiven"
 msgid "Enabled:"
 msgstr "Ingeschakeld:"
 
-#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:211
+#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:212
 #, kde-format
 msgid "Speed:"
 msgstr "Snelheid:"
@@ -253,7 +253,7 @@ msgstr "Verschuiflocatie herstellen na pauzeren:"
 msgid "Playback controls customization"
 msgstr "Afspeelbediening aanpassen"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:421 src/contents/ui/config/Full.qml:217
 #, kde-format
 msgid "Background"
 msgstr "Achtergrond"
@@ -287,50 +287,60 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Pictogram wissen"
 
-#: src/contents/ui/config/Full.qml:27
+#: src/contents/ui/config/Full.qml:28
 #, kde-format
 msgid "Album cover"
 msgstr "Albumhoes"
 
-#: src/contents/ui/config/Full.qml:31
+#: src/contents/ui/config/Full.qml:32
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Plaatshouder van albumhoes:"
 
-#: src/contents/ui/config/Full.qml:34 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:35 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Kiezen…"
 
-#: src/contents/ui/config/Full.qml:42
+#: src/contents/ui/config/Full.qml:43
 #, fuzzy, kde-format
 msgid "Clear"
 msgstr "Pictogram wissen"
 
-#: src/contents/ui/config/Full.qml:64
+#: src/contents/ui/config/Full.qml:65
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Full.qml:216
-#, kde-format
-msgid "Background (desktop widget only)"
-msgstr "Achtergrond (alleen bureaubladwidget)"
-
 #: src/contents/ui/config/Full.qml:226
+#, kde-format
+msgid "Background (desktop widget only):"
+msgstr "Achtergrond (alleen bureaubladwidget):"
+
+#: src/contents/ui/config/Full.qml:228
 #, kde-format
 msgid "Standard"
 msgstr "Standaard"
 
-#: src/contents/ui/config/Full.qml:242
+#: src/contents/ui/config/Full.qml:244
 #, kde-format
 msgid "Transparent"
 msgstr "Doorzichtig"
 
-#: src/contents/ui/config/Full.qml:253
+#: src/contents/ui/config/Full.qml:255
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Doorzichtig, met schaduw"
+
+#: src/contents/ui/config/Full.qml:272
+#, kde-format
+msgid "Use album cover as background:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:274
+#, kde-format
+msgid "(Experimental feature)"
+msgstr ""
 
 #: src/contents/ui/config/General.qml:26
 #, kde-format

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-28 18:04+0200\n"
+"POT-Creation-Date: 2025-08-28 18:06+0200\n"
 "PO-Revision-Date: 2025-07-21 13:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -33,12 +33,12 @@ msgstr "Paneelweergave"
 msgid "Full View"
 msgstr "Volledige weergave"
 
-#: src/contents/ui/Full.qml:97
+#: src/contents/ui/Full.qml:95
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-28 18:04+0200\n"
+"POT-Creation-Date: 2025-08-28 18:06+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,12 +32,12 @@ msgstr ""
 msgid "Full View"
 msgstr ""
 
-#: src/contents/ui/Full.qml:97
+#: src/contents/ui/Full.qml:95
 #, kde-format
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-14 23:27-0400\n"
+"POT-Creation-Date: 2025-08-28 18:04+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,12 +32,12 @@ msgstr ""
 msgid "Full View"
 msgstr ""
 
-#: src/contents/ui/Full.qml:55
+#: src/contents/ui/Full.qml:97
 #, kde-format
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:55 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:97 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""
@@ -142,41 +142,41 @@ msgstr ""
 msgid "Song text customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:177 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Song title position:"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:178
 #: src/contents/ui/config/Compact.qml:225
-#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:76
-#: src/contents/ui/config/Full.qml:123 src/contents/ui/config/Full.qml:168
+#: src/contents/ui/config/Compact.qml:270 src/contents/ui/config/Full.qml:77
+#: src/contents/ui/config/Full.qml:124 src/contents/ui/config/Full.qml:169
 #, kde-format
 msgid "Hidden"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:189
 #: src/contents/ui/config/Compact.qml:236
-#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:87
-#: src/contents/ui/config/Full.qml:134 src/contents/ui/config/Full.qml:179
+#: src/contents/ui/config/Compact.qml:281 src/contents/ui/config/Full.qml:88
+#: src/contents/ui/config/Full.qml:135 src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "First line"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:200
 #: src/contents/ui/config/Compact.qml:247
-#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:98
-#: src/contents/ui/config/Full.qml:145 src/contents/ui/config/Full.qml:190
+#: src/contents/ui/config/Compact.qml:292 src/contents/ui/config/Full.qml:99
+#: src/contents/ui/config/Full.qml:146 src/contents/ui/config/Full.qml:191
 #, kde-format
 msgid "Second line"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Compact.qml:224 src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Artists position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Compact.qml:269 src/contents/ui/config/Full.qml:168
 #, kde-format
 msgid "Album title position:"
 msgstr ""
@@ -196,7 +196,7 @@ msgstr ""
 msgid "max width:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Compact.qml:331 src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Text scrolling"
 msgstr ""
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Enabled:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:211
+#: src/contents/ui/config/Compact.qml:345 src/contents/ui/config/Full.qml:212
 #, kde-format
 msgid "Speed:"
 msgstr ""
@@ -246,7 +246,7 @@ msgstr ""
 msgid "Playback controls customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:421 src/contents/ui/config/Full.qml:217
 #, kde-format
 msgid "Background"
 msgstr ""
@@ -278,49 +278,59 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:27
+#: src/contents/ui/config/Full.qml:28
 #, kde-format
 msgid "Album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:31
+#: src/contents/ui/config/Full.qml:32
 #, kde-format
 msgid "Album placeholder:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:34 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:35 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:42
+#: src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Clear"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:64
+#: src/contents/ui/config/Full.qml:65
 #, kde-format
 msgid "Song Text Customization"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:216
+#: src/contents/ui/config/Full.qml:226
 #, kde-format
-msgid "Background (desktop widget only)"
+msgid "Background (desktop widget only):"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:226
+#: src/contents/ui/config/Full.qml:228
 #, kde-format
 msgid "Standard"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:242
+#: src/contents/ui/config/Full.qml:244
 #, kde-format
 msgid "Transparent"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:253
+#: src/contents/ui/config/Full.qml:255
 #, kde-format
 msgid "Transparent (Shadow content)"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:272
+#, kde-format
+msgid "Use album cover as background:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:274
+#, kde-format
+msgid "(Experimental feature)"
 msgstr ""
 
 #: src/contents/ui/config/General.qml:26


### PR DESCRIPTION
**Some screenshots:**

<img width="280" height="400" alt="screen-1" src="https://github.com/user-attachments/assets/0bb78d22-068d-414f-b41b-0e1669906fdf" />

<img width="270" height="400" alt="screen-2" src="https://github.com/user-attachments/assets/0808103b-54dd-48cf-86a3-c85b799b1ceb" />

<img width="270" height="400" alt="screen-3" src="https://github.com/user-attachments/assets/9e003319-39cb-429a-92fb-4943ae51ea1c" />


**Alternative version without borders:**

<img width="270" height="400" alt="screen-3-without-clip" src="https://github.com/user-attachments/assets/dfcf85d2-ad8c-432a-b2d9-15df82b57a96" />


I like the version without borders, but I don't like that it loses the border radius of the widget popup.

I appreciate any feedback or suggestions to improve this implementation

