### PR TITLE
Add a clear button for the album placeholder option

### DIFF
--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -37,6 +37,15 @@ KCM.SimpleKCM {
                     albumPlaceholderDialog.open()
                 }
             }
+
+            Button {
+                text: i18n("Clear")
+                icon.name: "edit-delete"
+                visible: albumPlaceholderDialog.value
+                onClicked: {
+                    albumPlaceholderDialog.value = ""
+                }
+            }
         }
 
         ColumnLayout {


### PR DESCRIPTION
This adds a button to delete the album placeholder set in the Full config page. Not entirely sure if this is needed, but I noticed that there wasn't an easy way to choose to have no placeholder once you have chosen one.