### PR TITLE
fix: Image source binding loop

### DIFF
--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -30,25 +30,20 @@ Item {
         height: column.height
         width: column.width
 
-        Image {
+        ImageWithPlaceholder {
             id: albumArtFull
             anchors.top: parent.top
             anchors.horizontalCenter: parent.horizontalCenter
             height: parent.height * 0.7
             width: parent.width
             fillMode: Image.PreserveAspectCrop
+            placeholderSource: albumPlaceholder
+            imageSource: player.artUrl
 
             onStatusChanged: {
                 if (status === Image.Ready) {
                     imageColors.update()
                 }
-            }
-
-            source: {
-                if (status === Image.Error || !player.artUrl) {
-                    return albumPlaceholder;
-                }
-                return player.artUrl;
             }
 
             Kirigami.ImageColors {
@@ -106,18 +101,14 @@ Item {
                 hoverEnabled: true
             }
 
-            Image {
+            ImageWithPlaceholder {
                 visible: !albumCoverBackground
                 id: albumArtNormal
                 anchors.fill: parent
-                source: {
-                    if (status === Image.Error || !player.artUrl) {
-                        return albumPlaceholder;
-                    }
-                    return player.artUrl;
-                }
-
                 fillMode: Image.PreserveAspectFit
+
+                placeholderSource: albumPlaceholder
+                imageSource: player.artUrl
             }
         }
 

--- a/src/contents/ui/components/ImageWithPlaceholder.qml
+++ b/src/contents/ui/components/ImageWithPlaceholder.qml
@@ -1,0 +1,22 @@
+import QtQuick
+
+Image {
+    id: imageWithPlaceholder
+
+    property string placeholderSource
+    property string imageSource
+    property bool imageLoadFailed: false
+
+    onImageSourceChanged: {
+        // Reset the flag when the image URL changes
+        imageLoadFailed = false
+    }
+
+    onStatusChanged: {
+        if (status === Image.Error) {
+            imageLoadFailed = true;
+        }
+    }
+
+    source: imageLoadFailed || !imageSource ? placeholderSource : imageSource
+}

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 11:36-0600\n"
+"POT-Creation-Date: 2025-09-27 12:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,12 +32,12 @@ msgstr "Vista pannello"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:95
+#: src/contents/ui/Full.qml:90
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:90 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 11:36-0600\n"
+"POT-Creation-Date: 2025-09-27 12:49+0200\n"
 "PO-Revision-Date: 2025-07-21 13:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -33,12 +33,12 @@ msgstr "Paneelweergave"
 msgid "Full View"
 msgstr "Volledige weergave"
 
-#: src/contents/ui/Full.qml:95
+#: src/contents/ui/Full.qml:90
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:90 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-09 11:36-0600\n"
+"POT-Creation-Date: 2025-09-27 12:49+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,12 +32,12 @@ msgstr ""
 msgid "Full View"
 msgstr ""
 
-#: src/contents/ui/Full.qml:95
+#: src/contents/ui/Full.qml:90
 #, kde-format
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:95 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:90 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""


### PR DESCRIPTION
Add a new ImageWithPlaceholder component that handle image fallback to placeholder image without generate a binding loop.

Closes #230 