### PR TITLE
Increase max controls size

### DIFF
--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -460,7 +460,7 @@ KCM.SimpleKCM {
             Layout.preferredWidth: 10 * Kirigami.Units.gridUnit
             id: panelControlsSizeRatio
             from: 0.6
-            to: 1
+            to: 1.1
             stepSize: 0.05
             Kirigami.FormData.label: i18n("Size:")
         }


### PR DESCRIPTION
1 is too small for my 20pt panel, 1.1 is just perfect. It doesn't look too out of place, so I think having a wider range of option will be better for everyone else as well
<img width="245" height="32" alt="Знімок 2025-09-30 00:34:16" src="https://github.com/user-attachments/assets/e1fe2ece-166e-46cd-838a-52ab1439d152" />
