### PR TITLE
feat: option for compact controls in panel view

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -96,8 +96,8 @@
         <entry name="panelControlsSizeRatio" type="Double">
             <default>0.75</default>
         </entry>
-        <entry name="panelControlsCompact" type="Bool">
-            <default>false</default>
+        <entry name="spaceBetweenControlsInPanel" type="Bool">
+            <default>true</default>
         </entry>
         <entry name="titlePosition" type="Int">
             <default>1</default>

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -23,7 +23,7 @@ Item {
 
     readonly property int widgetThickness: horizontal ? height : width
     readonly property int controlsSize: Math.round(widgetThickness * plasmoid.configuration.panelControlsSizeRatio)
-    readonly property bool compactControls: plasmoid.configuration.panelControlsCompact
+    readonly property bool spaceBetweenControlsInPanel: plasmoid.configuration.spaceBetweenControlsInPanel
     readonly property int iconSize: Math.round(widgetThickness * plasmoid.configuration.panelIconSizeRatio)
     readonly property int lengthMargin: Math.round((widgetThickness - Math.max(controlsSize, iconSize))) / 2
 
@@ -212,8 +212,8 @@ Item {
         GridLayout {
             columns: horizontal ? grid.children.length : 1
             rows: horizontal ? 1 : grid.children.length
-            columnSpacing: compactControls ? 0 : Kirigami.Units.smallSpacing
-            rowSpacing: compactControls ? 0 : Kirigami.Units.smallSpacing
+            columnSpacing: spaceBetweenControlsInPanel ? Kirigami.Units.smallSpacing : 0
+            rowSpacing: spaceBetweenControlsInPanel ? Kirigami.Units.smallSpacing : 0
 
             Layout.fillHeight: horizontal
             Layout.fillWidth: !horizontal

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -33,7 +33,7 @@ KCM.SimpleKCM {
     property alias cfg_songTextAlignment: songTextPositionRadio.value
     property alias cfg_panelIconSizeRatio: panelIconSizeRatio.value
     property alias cfg_panelControlsSizeRatio: panelControlsSizeRatio.value
-    property alias cfg_panelControlsCompact: panelControlCompact.checked
+    property alias cfg_spaceBetweenControlsInPanel: spaceBetweenControlsInPanel.checked
     property alias cfg_artistsPosition: artistsPosition.value
     property alias cfg_titlePosition: titlePosition.value
     property alias cfg_albumPosition: albumPosition.value
@@ -466,8 +466,8 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Size:")
         }
         CheckBox {
-            id: panelControlCompact
-            Kirigami.FormData.label: i18n("Compact mode")
+            id: spaceBetweenControlsInPanel
+            Kirigami.FormData.label: i18n("Space between controls")
         }
 
         Kirigami.Separator {

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 21:59+0200\n"
+"POT-Creation-Date: 2025-10-05 13:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -278,7 +278,7 @@ msgstr "Personalizzazione comandi di riproduzione"
 
 #: src/contents/ui/config/Compact.qml:470
 #, kde-format
-msgid "Compact mode"
+msgid "Space between controls"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:475 src/contents/ui/config/Full.qml:217

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 21:59+0200\n"
+"POT-Creation-Date: 2025-10-05 13:13+0200\n"
 "PO-Revision-Date: 2025-07-21 13:16+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -280,7 +280,7 @@ msgstr "Afspeelbediening aanpassen"
 
 #: src/contents/ui/config/Compact.qml:470
 #, kde-format
-msgid "Compact mode"
+msgid "Space between controls"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:475 src/contents/ui/config/Full.qml:217

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-30 22:34+0200\n"
+"POT-Creation-Date: 2025-10-05 13:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -273,7 +273,7 @@ msgstr ""
 
 #: src/contents/ui/config/Compact.qml:470
 #, kde-format
-msgid "Compact mode"
+msgid "Space between controls"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:475 src/contents/ui/config/Full.qml:217

--- a/src/translate/uk.po
+++ b/src/translate/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-03 00:12+0200\n"
+"POT-Creation-Date: 2025-10-05 13:13+0200\n"
 "PO-Revision-Date: 2025-09-30 01:49+0200\n"
 "Last-Translator: Vsevolod «Damglador» Stopchanskyi "
 "<vse.stopchanskyi@gmail.com>\n"
@@ -277,8 +277,8 @@ msgstr "Елементи керування відтворення"
 
 #: src/contents/ui/config/Compact.qml:470
 #, kde-format
-msgid "Compact mode"
-msgstr "Компактний режим"
+msgid "Space between controls"
+msgstr "Відступ між кнопками"
 
 #: src/contents/ui/config/Compact.qml:475 src/contents/ui/config/Full.qml:217
 #, kde-format


### PR DESCRIPTION
Adds an option to reduce spacing between playback control buttons to
zero, because they were too far apart imho.
Without compact mode:
<img width="315" height="20" alt="image" src="https://github.com/user-attachments/assets/515442d3-da63-4062-bc6d-27e6994c1b5e" />
Compact mode:
<img width="306" height="22" alt="image" src="https://github.com/user-attachments/assets/de2bf0f9-86e3-4a84-b931-ac428de4034b" />

I'm not sure about the naming in settings, I can change it if needed.