### PR TITLE
fix: thumbnail sizing for image components in PanelIcon

### DIFF
--- a/src/contents/ui/components/PanelIcon.qml
+++ b/src/contents/ui/components/PanelIcon.qml
@@ -22,9 +22,13 @@ Item {
     visible: type === PanelIcon.Type.Icon || imageReady || (fallbackToIconWhenImageNotAvailable && !imageReady)
 
     implicitHeight: size
-    implicitWidth: type === PanelIcon.Type.Image && imageComponent.status === Image.Ready && imageComponent.implicitHeight > 0
-        ? size * (imageComponent.implicitWidth / imageComponent.implicitHeight)
-        : size
+    implicitWidth: {
+        if (type === PanelIcon.Type.Image && imageReady && imageComponent.implicitHeight > 0) {
+            return size * (imageComponent.implicitWidth / imageComponent.implicitHeight);
+        } else {
+            return size;
+        }
+    }
 
     Kirigami.Icon {
         visible: type === PanelIcon.Type.Icon || (fallbackToIconWhenImageNotAvailable && !imageReady)


### PR DESCRIPTION
Adjust thumbnail sizing logic to ensure correct aspect ratio for image components in the PanelIcon. This change improves the display of images by dynamically calculating width based on height and [allows non-square thumbnails in Panel View take full height](https://github.com/ccatterina/plasmusic-toolbar/issues/261).

<img width="386" height="47" alt="image" src="https://github.com/user-attachments/assets/db950204-ffc9-4a81-a512-404e6cc0876a" />
<img width="383" height="47" alt="image" src="https://github.com/user-attachments/assets/ec8c997b-2f63-4bb5-873f-1d06eda99a93" />

