### PR TITLE
Fix binding loop on animationRunning in ScrollingText

### DIFF
--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -82,9 +82,12 @@ Item {
 
     PlasmaComponents3.Label {
         id: label
-        text: overflow ? (root.overflowElides && !animationRunning ? elidedMetrics.elidedText : root.textAndSpacing) : root.text
+        // _animationActive intentionally excludes label.x to avoid a binding loop:
+        // animationRunning → text → implicitWidth → animation.to → label.x → animationRunning
+        property bool _animationActive: !animation.paused && animation.running
+        property bool animationRunning: label.x !== 0 || _animationActive
+        text: overflow ? (root.overflowElides && !_animationActive ? elidedMetrics.elidedText : root.textAndSpacing) : root.text
         color: root.textColor
-        property bool animationRunning: label.x !== 0 || (!animation.paused && animation.running)
 
         NumberAnimation on x {
             id: animation


### PR DESCRIPTION
Hey, sorry it took me a bit but here's the PR for the animationRunning binding loop.

The problem was that `animationRunning` depends on `label.x`, and it was used in the `text` binding. Changing `text` changes `implicitWidth`, which changes `animation.to`, which changes `label.x` — completing the loop.

I split it into `_animationActive` (just `!animation.paused && animation.running`, no `label.x`) which is used in the `text` binding, and kept `animationRunning` with the `label.x !== 0` check for the visibility and layer properties since those don't feed back into the animation.

Fixes #249