### PR TITLE
feat: reduce default maximum width

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -160,7 +160,7 @@
             <default>100</default>
         </entry>
         <entry name="fullViewMaxWidth" type="Int">
-            <default>1000</default>
+            <default>300</default>
         </entry>
 		<entry name="fullAlbumCoverRounded" type="Bool">
 			<default>true</default>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -36,9 +36,9 @@ Item {
     readonly property int contentMinWidth: row.visible ? row.implicitWidth + 40 : 0
     readonly property int effectiveMinWidth: Math.min(Math.max(configMinWidth, contentMinWidth), maximumWidth)
 
-    Layout.preferredWidth: maximumWidth
     Layout.minimumWidth: effectiveMinWidth
     Layout.maximumWidth: maximumWidth
+    Layout.preferredWidth: effectiveMinWidth
     Layout.preferredHeight: column.implicitHeight
     Layout.minimumHeight: column.implicitHeight
     Layout.maximumHeight: column.implicitHeight


### PR DESCRIPTION
Since cover images generally have high resolution, the `fullViewMaxWidth` parameter essentially acts as the default width. With that in mind, I felt the default of 1000px was a bit too large, so I've lowered it to 300px, which roughly corresponds to the widget's size before the `fullViewMaxWidth`  configuration was added.

cc @Nicolas-Gth 
