### PR TITLE
fix: align song text in panel on song change

### DIFF
--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -175,9 +175,6 @@ Item {
             SongAndArtistText {
                 id: songAndArtistText
 
-                // Fill songGrid entirely; text centering is handled by
-                // staticLabel.horizontalAlignment inside ScrollingText.
-                // This avoids all async layout positioning issues.
                 width: horizontal ? songGrid.width : songGrid.height
                 height: horizontal ? songGrid.height : songGrid.width
                 x: horizontal ? 0 : (songGrid.width - songGrid.height) / 2

--- a/src/contents/ui/Compact.qml
+++ b/src/contents/ui/Compact.qml
@@ -157,81 +157,66 @@ Item {
             Layout.fillWidth: true
         }
 
-        GridLayout {
+        Item {
             id: songGrid
             visible: plasmoid.configuration.songTextInPanel
-
-            columns: horizontal ? songGrid.children.length : 1
-            rows: horizontal ? 1 : songGrid.children.length
 
             readonly property int textAlignment: plasmoid.configuration.songTextAlignment
             readonly property int fxdWidth: plasmoid.configuration.songTextFixedWidth + 2 * Kirigami.Units.smallSpacing
             readonly property bool useFixedWidth: plasmoid.configuration.useSongTextFixedWidth
             readonly property int length: horizontal ? width : height
 
-            Layout.preferredWidth: horizontal && useFixedWidth && !fillAvailableSpace ? fxdWidth : -1
-            Layout.preferredHeight: !horizontal && useFixedWidth && !fillAvailableSpace ? fxdWidth : -1
+            Layout.preferredWidth: horizontal && useFixedWidth && !fillAvailableSpace ? fxdWidth : (horizontal ? songAndArtistText.calculatedWidth : -1)
+            Layout.preferredHeight: !horizontal && useFixedWidth && !fillAvailableSpace ? fxdWidth : (!horizontal ? songAndArtistText.calculatedWidth : -1)
             Layout.fillHeight: horizontal || fillAvailableSpace
             Layout.fillWidth: !horizontal || fillAvailableSpace
             Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
 
-            Item {
-                readonly property bool fill: [Qt.AlignRight, Qt.AlignCenter].includes(songGrid.textAlignment)
-                Layout.fillHeight: !horizontal && fill
-                Layout.fillWidth: horizontal && fill
-            }
+            SongAndArtistText {
+                id: songAndArtistText
 
-            Item {
-                Layout.fillHeight: horizontal
-                Layout.fillWidth: !horizontal
-                Layout.preferredHeight: !horizontal ? songAndArtistText.width : null
-                Layout.preferredWidth: horizontal ? songAndArtistText.width : null
+                // Fill songGrid entirely; text centering is handled by
+                // staticLabel.horizontalAlignment inside ScrollingText.
+                // This avoids all async layout positioning issues.
+                width: horizontal ? songGrid.width : songGrid.height
+                height: horizontal ? songGrid.height : songGrid.width
+                x: horizontal ? 0 : (songGrid.width - songGrid.height) / 2
+                y: horizontal ? 0 : (songGrid.height - songGrid.width) / 2
 
-                SongAndArtistText {
-                    id: songAndArtistText
-                    anchors.centerIn: parent
-
-                    rotation: {
-                        if (horizontal) return 0
-                        if (widget.location === PlasmaCore.Types.LeftEdge) return -90
-                        if (widget.location === PlasmaCore.Types.RightEdge) return 90
-                    }
-
-                    maxWidth: {
-                        if (fillAvailableSpace || songGrid.useFixedWidth) {
-                            return songGrid.length
-                        }
-                        return plasmoid.configuration.maxSongWidthInPanel
-                    }
-                    scrollingBehaviour: plasmoid.configuration.textScrollingBehaviour
-                    scrollingSpeed: plasmoid.configuration.textScrollingSpeed
-                    scrollingResetOnPause: plasmoid.configuration.textScrollingResetOnPause
-                    scrollingEnabled: plasmoid.configuration.textScrollingEnabled
-                    titlePosition: plasmoid.configuration.titlePosition
-                    artistsPosition: plasmoid.configuration.artistsPosition
-                    albumPosition: plasmoid.configuration.albumPosition
-                    hideAlbumForSingles: plasmoid.configuration.compactHideAlbumForSingles
-                    forcePauseScrolling: {
-                        if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
-                            return false
-                        }
-                        return player.playbackStatus !== Mpris.PlaybackStatus.Playing
-                    }
-                    textFont: baseFont
-                    color: foregroundColor
-                    title: player.title
-                    artists: player.artists
-                    album: player.album
-                    textAlignment: songGrid.textAlignment
-                    truncateStyle: plasmoid.configuration.compactTruncatedTextStyle
-                    opacity: player.playbackStatus === Mpris.PlaybackStatus.Playing ? 1.0 : 0.75
+                rotation: {
+                    if (horizontal) return 0
+                    if (widget.location === PlasmaCore.Types.LeftEdge) return -90
+                    if (widget.location === PlasmaCore.Types.RightEdge) return 90
                 }
-            }
 
-            Item {
-                readonly property bool fill: [Qt.AlignLeft, Qt.AlignCenter].includes(songGrid.textAlignment)
-                Layout.fillHeight: !horizontal && fill
-                Layout.fillWidth: horizontal && fill
+                maxWidth: {
+                    if (fillAvailableSpace || songGrid.useFixedWidth) {
+                        return songGrid.length
+                    }
+                    return plasmoid.configuration.maxSongWidthInPanel
+                }
+                scrollingBehaviour: plasmoid.configuration.textScrollingBehaviour
+                scrollingSpeed: plasmoid.configuration.textScrollingSpeed
+                scrollingResetOnPause: plasmoid.configuration.textScrollingResetOnPause
+                scrollingEnabled: plasmoid.configuration.textScrollingEnabled
+                titlePosition: plasmoid.configuration.titlePosition
+                artistsPosition: plasmoid.configuration.artistsPosition
+                albumPosition: plasmoid.configuration.albumPosition
+                hideAlbumForSingles: plasmoid.configuration.compactHideAlbumForSingles
+                forcePauseScrolling: {
+                    if (!plasmoid.configuration.pauseTextScrollingWhileMediaIsNotPlaying) {
+                        return false
+                    }
+                    return player.playbackStatus !== Mpris.PlaybackStatus.Playing
+                }
+                textFont: baseFont
+                color: foregroundColor
+                title: player.title
+                artists: player.artists
+                album: player.album
+                textAlignment: songGrid.textAlignment
+                truncateStyle: plasmoid.configuration.compactTruncatedTextStyle
+                opacity: player.playbackStatus === Mpris.PlaybackStatus.Playing ? 1.0 : 0.75
             }
         }
 

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -97,7 +97,6 @@ Item {
         visible: overflow
         text: overflow ? (root.overflowElides && showElided ? elidedMetrics.elidedText : root.textAndSpacing) : root.text
         color: root.textColor
-        // Break binding loop: use animation.running/paused directly instead of label.x
         property bool showElided: !animation.running || animation.paused
         property bool animationRunning: label.x !== 0 || (!animation.paused && animation.running)
 

--- a/src/contents/ui/components/ScrollingText.qml
+++ b/src/contents/ui/components/ScrollingText.qml
@@ -95,8 +95,10 @@ Item {
     PlasmaComponents3.Label {
         id: label
         visible: overflow
-        text: overflow ? (root.overflowElides && !animationRunning ? elidedMetrics.elidedText : root.textAndSpacing) : root.text
+        text: overflow ? (root.overflowElides && showElided ? elidedMetrics.elidedText : root.textAndSpacing) : root.text
         color: root.textColor
+        // Break binding loop: use animation.running/paused directly instead of label.x
+        property bool showElided: !animation.running || animation.paused
         property bool animationRunning: label.x !== 0 || (!animation.paused && animation.running)
 
         NumberAnimation on x {

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -68,7 +68,6 @@ ColumnLayout {
     property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
     property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
 
-    // Synchronous width computation bypassing ColumnLayout polish delay
     readonly property real calculatedWidth: Math.max(
         firstLine.visible ? firstLine.implicitWidth : 0,
         secondLine.visible ? secondLine.implicitWidth : 0

--- a/src/contents/ui/components/SongAndArtistText.qml
+++ b/src/contents/ui/components/SongAndArtistText.qml
@@ -68,8 +68,15 @@ ColumnLayout {
     property string finalFirstText:  firstLineArray.filter((x) => x).join(" - ")
     property string finalSecondText: secondLineArray.filter((x) => x).join(" - ")
 
+    // Synchronous width computation bypassing ColumnLayout polish delay
+    readonly property real calculatedWidth: Math.max(
+        firstLine.visible ? firstLine.implicitWidth : 0,
+        secondLine.visible ? secondLine.implicitWidth : 0
+    )
+
     // first row of text (the only row, if there is only one)
     ScrollingText {
+        id: firstLine
         // visible only when necessary
         visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour
@@ -89,6 +96,7 @@ ColumnLayout {
 
     // second row of text
     ScrollingText {
+        id: secondLine
         // visible only when necessary
         visible: text.length !== 0
         overflowBehaviour: root.scrollingBehaviour


### PR DESCRIPTION
PR #267 introduced a circular width dependency in the panel text layout: `ScrollingText` was changed from explicit `width` + `Layout.preferredWidth` to `Layout.fillWidth: true`, which meant the text container's width was assigned by the parent layout rather than computed from the text content. On song change, the centering position was calculated from the stale (previous song) width and never updated.

Here's my fix:

Instead of resizing the text box to fit the content and then centering it, the text box now always takes up all available space and the text is centered visually inside it.

Also fixes a binding loop on `animationRunning`/`text` in ScrollingText.qml.

This should fix https://github.com/ccatterina/plasmusic-toolbar/issues/280