### PR TITLE
Added missing line to support album hiding

### DIFF
--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -188,6 +188,7 @@ Item {
             titlePosition: plasmoid.configuration.fullTitlePosition
             artistsPosition: plasmoid.configuration.fullArtistsPosition
             albumPosition: plasmoid.configuration.fullAlbumPosition
+            hideAlbumForSingles: plasmoid.configuration.fullHideAlbumForSingles
         }
 
         TrackPositionSlider {


### PR DESCRIPTION
The album name is now properly hidden with the hide album name for singles option even if the song and artist text is above the track pos slider