### PR TITLE
Hide player binds in tooltip

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -180,5 +180,8 @@
         <entry name="mediaProgressInPanel" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="hidePlayerControlBindsInHoverTooltip" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/config/Compact.qml
+++ b/src/contents/ui/config/Compact.qml
@@ -40,6 +40,7 @@ KCM.SimpleKCM {
     property alias cfg_compactTruncatedTextStyle: compactTruncatedTextStyle.value
     property alias cfg_mediaProgressInPanel: mediaProgressInPanel.checked
     property alias cfg_compactHideAlbumForSingles: compactHideAlbumForSingles.checked
+    property alias cfg_hidePlayerControlBindsInHoverTooltip: hidePlayerControlBindsInHoverTooltip.checked
 
     Kirigami.FormLayout {
         id: form
@@ -515,6 +516,16 @@ KCM.SimpleKCM {
             to: 25
             stepSize: 2
             Kirigami.FormData.label: i18n("Background radius:")
+        }
+
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Hover tooltip")
+        }
+
+        CheckBox{
+            id: hidePlayerControlBindsInHoverTooltip
+            Kirigami.FormData.label: i18n("Hide player control keybinds in tooltip")
         }
     }
 }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -16,6 +16,7 @@ PlasmoidItem {
     readonly property int formFactor: Plasmoid.formFactor
     readonly property int location: Plasmoid.location
     readonly property bool showWhenNoMedia: plasmoid.configuration.showWhenNoMedia
+    readonly property bool hidePlayerControlBinds: plasmoid.configuration.hidePlayerControlBindsInHoverTooltip
 
     readonly property font baseFont: plasmoid.configuration.useCustomFont ? plasmoid.configuration.customFont : Kirigami.Theme.defaultFont
 
@@ -24,9 +25,11 @@ PlasmoidItem {
     toolTipSubText: {
         let text = player.artists ? i18nc("%1 is the media artist/author and %2 is the player name", "by %1 (%2)", player.artists, player.identity)
             : i18nc("%1 is the player name", "%1", player.identity)
-        text += "\n" + (player.playbackStatus === Mpris.PlaybackStatus.Playing ? i18n("Middle-click to pause") : i18n("Middle-click to play"))
-        text += "\n" + i18n("Scroll to adjust volume")
-        text += "\n" + (player.canRaise ? i18n("Ctrl+Click to bring player to the front") : i18n("This player can't be raised"))
+        if(!hidePlayerControlBinds){
+            text += "\n" + (player.playbackStatus === Mpris.PlaybackStatus.Playing ? i18n("Middle-click to pause") : i18n("Middle-click to play"))
+            text += "\n" + i18n("Scroll to adjust volume")
+            text += "\n" + (player.canRaise ? i18n("Ctrl+Click to bring player to the front") : i18n("This player can't be raised"))
+        }
         return text
     }
 

--- a/src/translate/fr.po
+++ b/src/translate/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: 2026-02-23 00:22+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,22 +37,22 @@ msgstr "Vue complète"
 msgid "Bring player to the front"
 msgstr "Mettre le lecteur au premier plan"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Ce lecteur ne peut pas être mis au premier plan"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr "Disposition"
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr "Remplir l'espace disponible dans le panneau"
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -65,260 +65,270 @@ msgstr ""
 "haut) et les contrôles de lecture sont alignés à droite (ou en bas) ; le "
 "texte de la chanson peut être positionné selon les préférences."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Alignement du texte :"
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr "Gauche (Haut pour panneau vertical)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr "Centre"
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr "Droite (Bas pour panneau vertical)"
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr "Afficher l'icône :"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr "Afficher le texte de la chanson"
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr "Afficher le contrôle de retour arrière"
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr "Afficher le contrôle lecture/pause"
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr "Afficher le contrôle d'avance rapide"
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr "Personnalisation de l'icône"
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr "Icône :"
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr "Taille :"
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr "Utiliser la pochette comme icône"
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr "Revenir à l'icône si la pochette n'est pas disponible"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrondi de la pochette :"
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr "Personnalisation du texte du titre"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr "Position du titre :"
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr "Caché"
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr "Première ligne"
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr "Deuxième ligne"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr "Position de l'artiste :"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr "Position du titre d'album :"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr "Utiliser une largeur fixe"
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr "Largeur fixe :"
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr "Largeur max :"
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr "Style du texte tronqué :"
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr ""
 "Fonctionne uniquement lorsque le texte ne défile pas et est en position "
 "initiale"
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr "Ellipse"
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr "Fondu"
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr "Aucun"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr "Défilement du texte"
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr "Vitesse :"
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr "Lorsque le texte déborde :"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr "Toujours défiler"
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr "Défiler uniquement au survol"
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr "Toujours défiler sauf au survol"
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr "Mettre le défilement en pause si le média n'est pas en lecture"
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr "Réinitialiser la position lorsque le défilement est en pause"
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr "Personnalisation des contrôles de lecture"
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr "Espace entre les contrôles"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr "Fond"
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr "Progression du média"
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr "Couleurs de la pochette"
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr ""
 "\"Utiliser la pochette comme icône\" doit être activé pour que le fond "
 "fonctionne."
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, kde-format
 msgid "Background radius:"
 msgstr "Arrondi du fond :"
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
+msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
 #, kde-format
@@ -561,39 +571,39 @@ msgstr "Pas du volume :"
 msgid "Choose a Font"
 msgstr "Choisir une police"
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "Aucun média en lecture"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "par %1 (%2)"
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "Clic du milieu pour mettre en pause"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "Clic du milieu pour lire"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "Défilement pour ajuster le volume"
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+Clic pour mettre le lecteur au premier plan"

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,22 +37,22 @@ msgstr "Vista completa"
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr "Disposizione"
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr "Riempi lo spazio disponibile nel pannello"
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -66,258 +66,268 @@ msgstr ""
 "il testo della canzone può essere posizionato in base alle preferenze "
 "dell'utente."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Allineamento brano:"
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr "Sinistra (Alto per pannello verticale)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr "Centro"
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr "Destra (Basso per pannello verticale)"
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr "Mostra icona:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr "Mostra brano"
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr "Mostra comando indietro"
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr "Mostra comando riproduci/pausa"
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr "Mostra comando avanti"
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr "Personalizzazione icona"
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr "Icona:"
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr "Dimensione:"
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr "Usa copertina album come icona"
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr "Usa icona se la copertina non è disponibile"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrotondamento bordo copertina album:"
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr "Personalizzazione testo brano"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr "Posizionamento titolo:"
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr "Nascosto"
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr "Prima riga"
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr "Seconda riga"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr "Posizione artista/i:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr "Posizione titolo album:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr "Usa larghezza fissa"
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr "larghezza fissa:"
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr "larghezza massima:"
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr "Scorrimento testo"
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr "Velocità:"
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr "Quando il testo eccede:"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr "Scorri sempre"
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr "Scorri solo al passaggio del mouse"
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr "Scorri sempre tranne al passaggio del mouse"
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr "Ferma scorrimento quando il media è in pausa"
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr "Reimposta posizione quando lo scorrimento è in pausa"
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr "Personalizzazione comandi di riproduzione"
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr "Sfondo"
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr "Colori dalla copertina dell'album"
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr ""
 "Perché lo sfondo funzioni, deve essere selezionata l'opzione 'Usa copertina "
 "album come icona'."
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, fuzzy, kde-format
 msgid "Background radius:"
 msgstr "Arrotondamento bordi sfondo:"
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
+msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
 #, kde-format
@@ -557,39 +567,39 @@ msgstr "Step volume:"
 msgid "Choose a Font"
 msgstr "Scegli un font"
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "Nessun media in riproduzione"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "di %1 (%2)"
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "Click centrale per mettere in pausa"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "Click centrale per riprodurre"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "Scorri per regolare il volume"
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+Click per portare il player in primo piano"

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: 2026-03-15 10:48+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -38,22 +38,22 @@ msgstr "Volledige weergave"
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr "Indeling"
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr "Alle beschikbare paneelruimte gebruiken"
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -66,134 +66,134 @@ msgstr ""
 "bovenaan uitgelijnd, en de afspeelbediening rechts of onderaan. De tekst kan "
 "op een locatie naar keuze worden getoond."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Tekst uitlijnen:"
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr "Links/Bovenaan"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr "Midden"
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr "Rechts/Onderaan"
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr "Pictogram tonen:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr "Titel van nummer tonen"
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr "Terugspoelknop tonen"
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr "Afspeel-/Pauzeerknop tonen"
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr "Vooruitspoelknop tonen"
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr "Pictogram aanpassen"
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr "Pictogram:"
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr "Afmetingen:"
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr "Albumhoes gebruiken als pictogram"
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr ""
 "Indien er geen hoes beschikbaar is, zal het standaardpictogram worden "
 "gebruikt"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albumhoesafmetingen:"
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr "Tekstlocatie:"
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr "Verborgen"
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr "Eerste regel"
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr "Tweede regel"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr "Artiestlocatie:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr "Albumtitellocatie:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Albumnaam verbergen indien gelijk aan single:"
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -201,127 +201,137 @@ msgstr ""
 "Als de albumnaam en titel van het nummer gelijk zijn, wordt de albumnaam "
 "niet getoond."
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr "Vaste breedte gebruiken"
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr "vaste breedte:"
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr "max. breedte:"
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr "Stijl van afgekapte tekst:"
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr "Werkt alleen als de tekst niet verschuift en op de beginpositie staat"
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr "Weglatingsteken"
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr "Vervaging"
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr "Geen"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr "Tekst laten verschuiven"
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr "Snelheid:"
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr "Als tekst buiten beeld valt:"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr "Altijd verschuiven"
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr "Verschuiven na aanwijzen met muis"
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr "Altijd verschuiven, behalve na aanwijzen met muis"
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr "Verschuiving onderbreken na pauzeren"
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr "Verschuiflocatie herstellen na pauzeren"
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr "Afspeelbediening aanpassen"
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr "Ruimte tussen bedieningsknoppen"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr "Achtergrond"
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr "Voortgangsbalk"
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr "Kleuren van albumhoes"
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr ""
 "De instelling om de albumhoes als pictogram te gebruiken dient ingeschakeld "
 "te zijn."
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, kde-format
 msgid "Background radius:"
 msgstr "Achtergrondradius:"
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
+msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
 #, kde-format
@@ -563,39 +573,39 @@ msgstr "Volumestap:"
 msgid "Choose a Font"
 msgstr "Kies een lettertype"
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "Er wordt niets afgespeeld"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "van %1 (%2)"
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "Middelklikken om te pauzeren"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "Middelklikken om af te spelen"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "Scrollen om volumeniveau aan te passen"
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+klikken om speler naar voorgrond te halen"

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -37,22 +37,22 @@ msgstr ""
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -61,255 +61,265 @@ msgid ""
 "positioned based on user preference."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, kde-format
 msgid "Background radius:"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
 msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
@@ -543,39 +553,39 @@ msgstr ""
 msgid "Choose a Font"
 msgstr ""
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr ""
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr ""
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr ""
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr ""
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr ""
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr ""
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr ""

--- a/src/translate/tr.po
+++ b/src/translate/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: 2026-03-08 00:00+0300\n"
 "Last-Translator: A coffee lover\n"
 "Language-Team: none\n"
@@ -37,22 +37,22 @@ msgstr "Tam Görünüm"
 msgid "Bring player to the front"
 msgstr "Oynatıcıyı öne getir"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Bu oynatıcı öne getirilemez"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr "Yerleşim"
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr "Paneldeki kullanılabilir alanı doldur"
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -65,259 +65,268 @@ msgstr ""
 "kontrolleri sağa (veya alta) hizalanır; şarkı metni kullanıcı tercihine göre "
 "konumlandırılabilir."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Şarkı metni hizalaması:"
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr "Sol (Dikey panel için üst)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr "Orta"
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr "Sağ (Dikey panel için alt)"
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr "Simgeyi göster:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr "Şarkı metnini göster"
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr "Geri atlama kontrolünü göster"
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr "Oynat/duraklat kontrolünü göster"
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr "İleri atlama kontrolünü göster"
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr "Simge özelleştirme"
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr "Simge:"
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr "Boyut:"
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr "Albüm kapağını simge olarak kullan"
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr "Kapak yoksa yerine simgeyi kullan"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albüm kapağı köşe yarıçapı:"
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr "Şarkı metni özelleştirme"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr "Şarkı adı konumu:"
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr "Gizli"
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr "İlk satır"
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr "İkinci satır"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr "Sanatçıların konumu:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr "Albüm adı konumu:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Tekli parçalarda albüm adını gizle:"
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
-msgstr ""
-"Albüm adı ve parça başlığı eşleşirse albüm adı gizlenecektir."
+msgstr "Albüm adı ve parça başlığı eşleşirse albüm adı gizlenecektir."
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr "Sabit genişlik kullan"
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr "Sabit genişlik:"
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr "maksimum genişlik:"
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr "Kısaltılmış metin stili:"
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr "Yalnızca metin kaymıyorken ve başlangıç konumundayken çalışır"
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr "Kısalt"
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr "Soldur"
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr "Hiçbiri"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr "Metin kaydırma"
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr "Hız:"
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr "Metin taştığında:"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr "Her zaman kaydır"
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr "Yalnızca fare üzerine geldiğinde kaydır"
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr "Fare üzerinde değilken her zaman kaydır"
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr "Medya oynatılmıyorken kaydırmayı duraklat"
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr "Kaydırma duraklatıldığında konumu sıfırla"
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr "Oynatma kontrolleri özelleştirme"
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr "Kontroller arası boşluk"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr "Arka plan"
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr "Medya ilerlemesi"
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr "Albüm kapağındaki renkler"
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr ""
 "Arka planın çalışması için albüm kapağını simge olarak kullan seçeneği "
 "işaretlenmelidir."
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, kde-format
 msgid "Background radius:"
 msgstr "Arka plan köşe yarıçapı:"
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
+msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
 #, kde-format
@@ -559,39 +568,39 @@ msgstr "Ses düzeyi adımı:"
 msgid "Choose a Font"
 msgstr "Yazı Tipi Seç"
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "Medya oynatılmıyor"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "%1 tarafından (%2)"
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "Orta fare tuşuyla duraklatın"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "Orta fare tuşuyla oynatın"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "Fare tekeriyle sesi ayarlayın"
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+Tıklayarak oynatıcıyı öne getirin"

--- a/src/translate/uk.po
+++ b/src/translate/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-09 21:39+0200\n"
 "PO-Revision-Date: 2025-09-30 01:49+0200\n"
 "Last-Translator: Vsevolod «Damglador» Stopchanskyi "
 "<vse.stopchanskyi@gmail.com>\n"
@@ -38,22 +38,22 @@ msgstr "Повний показ"
 msgid "Bring player to the front"
 msgstr "Сфокусувати програвач"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Цей програвач неможливо сфокусувати"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:43
 #, kde-format
 msgid "Layout"
 msgstr "Компонування"
 
-#: src/contents/ui/config/Compact.qml:53
+#: src/contents/ui/config/Compact.qml:54
 #, kde-format
 msgid "Fill available space in the panel"
 msgstr "Заповнити доступний простір панелі"
 
-#: src/contents/ui/config/Compact.qml:59
+#: src/contents/ui/config/Compact.qml:60
 #, kde-format
 msgid ""
 "The widget fills all available width in the horizontal panel (or height in "
@@ -65,256 +65,266 @@ msgstr ""
 "піктограмою ліворуч чи зверху та елементами керування праворуч чи унизу. "
 "Опис композиції може бути розташований за побажанням. "
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:62
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Розташування опису композиції"
 
-#: src/contents/ui/config/Compact.qml:71
+#: src/contents/ui/config/Compact.qml:72
 #, kde-format
 msgid "Left (Top for vertical panel)"
 msgstr "Ліворуч (зверху для вертикальних панелей)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:75
 #, kde-format
 msgid "Center"
 msgstr "По центру"
 
-#: src/contents/ui/config/Compact.qml:93
+#: src/contents/ui/config/Compact.qml:94
 #, kde-format
 msgid "Right (Bottom for vertical panel)"
 msgstr "Праворуч (унизу для вертикальних панелей)"
 
-#: src/contents/ui/config/Compact.qml:105
+#: src/contents/ui/config/Compact.qml:106
 #, kde-format
 msgid "Show icon:"
 msgstr "Показувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:100
 #, kde-format
 msgid "Show song text"
 msgstr "Показувати опис композиції"
 
-#: src/contents/ui/config/Compact.qml:115
+#: src/contents/ui/config/Compact.qml:116
 #, kde-format
 msgid "Show skip backward control"
 msgstr "Кнопка «Попередній»"
 
-#: src/contents/ui/config/Compact.qml:120
+#: src/contents/ui/config/Compact.qml:121
 #, kde-format
 msgid "Show play/pause control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Compact.qml:125
+#: src/contents/ui/config/Compact.qml:126
 #, kde-format
 msgid "Show skip forward control"
 msgstr "Кнопка «Наступний»"
 
-#: src/contents/ui/config/Compact.qml:130
+#: src/contents/ui/config/Compact.qml:131
 #, kde-format
 msgid "Icon customization"
 msgstr "Налаштування піктограми"
 
-#: src/contents/ui/config/Compact.qml:135
+#: src/contents/ui/config/Compact.qml:136
 #, kde-format
 msgid "Icon:"
 msgstr "Піктограма:"
 
-#: src/contents/ui/config/Compact.qml:144
-#: src/contents/ui/config/Compact.qml:480
+#: src/contents/ui/config/Compact.qml:145
+#: src/contents/ui/config/Compact.qml:481
 #, kde-format
 msgid "Size:"
 msgstr "Розмір:"
 
-#: src/contents/ui/config/Compact.qml:149
+#: src/contents/ui/config/Compact.qml:150
 #, kde-format
 msgid "Use album cover as icon"
 msgstr "Використовувати зображення альбому"
 
-#: src/contents/ui/config/Compact.qml:155
+#: src/contents/ui/config/Compact.qml:156
 #, kde-format
 msgid "Fallback to icon if cover is not available"
 msgstr "Інакше, використовувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:230
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Радіус зображення альбому:"
 
-#: src/contents/ui/config/Compact.qml:170
+#: src/contents/ui/config/Compact.qml:171
 #, kde-format
 msgid "Song text customization"
 msgstr "Налаштування опису композиції"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:246
 #, kde-format
 msgid "Song title position:"
 msgstr "Позиція назви композиції:"
 
-#: src/contents/ui/config/Compact.qml:182
-#: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
+#: src/contents/ui/config/Compact.qml:183
+#: src/contents/ui/config/Compact.qml:230
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:247
 #: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
 #, kde-format
 msgid "Hidden"
 msgstr "Прихований"
 
-#: src/contents/ui/config/Compact.qml:193
-#: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
+#: src/contents/ui/config/Compact.qml:194
+#: src/contents/ui/config/Compact.qml:241
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:258
 #: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
 #, kde-format
 msgid "First line"
 msgstr "Перший ряд"
 
-#: src/contents/ui/config/Compact.qml:204
-#: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
+#: src/contents/ui/config/Compact.qml:205
+#: src/contents/ui/config/Compact.qml:252
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:269
 #: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
 #, kde-format
 msgid "Second line"
 msgstr "Другий ряд"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:293
 #, kde-format
 msgid "Artists position:"
 msgstr "Позиція композитора:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:338
 #, kde-format
 msgid "Album title position:"
 msgstr "Позиція назви альбому:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:378
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:326
+#: src/contents/ui/config/Compact.qml:327
 #, kde-format
 msgid "Use fixed width"
 msgstr "Статична ширина"
 
-#: src/contents/ui/config/Compact.qml:333
+#: src/contents/ui/config/Compact.qml:334
 #, kde-format
 msgid "fixed width:"
 msgstr "Фіксована ширина:"
 
-#: src/contents/ui/config/Compact.qml:341
+#: src/contents/ui/config/Compact.qml:342
 #, kde-format
 msgid "max width:"
 msgstr "Максимальна ширина:"
 
-#: src/contents/ui/config/Compact.qml:351
+#: src/contents/ui/config/Compact.qml:352
 #, kde-format
 msgid "Truncated text style:"
 msgstr "Стиль обрізаного тексту:"
 
-#: src/contents/ui/config/Compact.qml:352
+#: src/contents/ui/config/Compact.qml:353
 #, kde-format
 msgid "Works only when the text is not scrolling and in the initial position"
 msgstr "Працює лише коли текст не прокручується та у початковій позиції"
 
-#: src/contents/ui/config/Compact.qml:361
+#: src/contents/ui/config/Compact.qml:362
 #, kde-format
 msgid "Elide"
 msgstr "Обрізання+,,,"
 
-#: src/contents/ui/config/Compact.qml:372
+#: src/contents/ui/config/Compact.qml:373
 #, kde-format
 msgid "Fade out"
 msgstr "Згасання"
 
-#: src/contents/ui/config/Compact.qml:383
+#: src/contents/ui/config/Compact.qml:384
 #, kde-format
 msgid "None"
 msgstr "Немає"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Text scrolling"
 msgstr "Прокручування тексту"
 
-#: src/contents/ui/config/Compact.qml:400
+#: src/contents/ui/config/Compact.qml:401
 #, kde-format
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Speed:"
 msgstr "Швидкість:"
 
-#: src/contents/ui/config/Compact.qml:419
+#: src/contents/ui/config/Compact.qml:420
 #, kde-format
 msgid "When text overflows:"
 msgstr "Прокручування коли забагато тексту:"
 
-#: src/contents/ui/config/Compact.qml:421
+#: src/contents/ui/config/Compact.qml:422
 #, kde-format
 msgid "Always scroll"
 msgstr "Завжди"
 
-#: src/contents/ui/config/Compact.qml:434
+#: src/contents/ui/config/Compact.qml:435
 #, kde-format
 msgid "Scroll only on mouse over"
 msgstr "Коли наведено мишею"
 
-#: src/contents/ui/config/Compact.qml:447
+#: src/contents/ui/config/Compact.qml:448
 #, kde-format
 msgid "Always scroll except on mouse over"
 msgstr "Коли НЕ наведено мишею"
 
-#: src/contents/ui/config/Compact.qml:460
+#: src/contents/ui/config/Compact.qml:461
 #, kde-format
 msgid "Pause scrolling while media is not playing"
 msgstr "Призупинити прокручування з композицією"
 
-#: src/contents/ui/config/Compact.qml:465
+#: src/contents/ui/config/Compact.qml:466
 #, kde-format
 msgid "Reset position when scrolling is paused"
 msgstr "Скинути позицію коли призупинено"
 
-#: src/contents/ui/config/Compact.qml:471
+#: src/contents/ui/config/Compact.qml:472
 #, kde-format
 msgid "Playback controls customization"
 msgstr "Елементи керування відтворення"
 
-#: src/contents/ui/config/Compact.qml:484
+#: src/contents/ui/config/Compact.qml:485
 #, kde-format
 msgid "Space between controls"
 msgstr "Відступ між кнопками"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:399
 #, kde-format
 msgid "Background"
 msgstr "Фон"
 
-#: src/contents/ui/config/Compact.qml:494
+#: src/contents/ui/config/Compact.qml:495
 #, kde-format
 msgid "Media progress"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:498
+#: src/contents/ui/config/Compact.qml:499
 #, kde-format
 msgid "Colors from album cover"
 msgstr "Кольори обкладинки альбому"
 
-#: src/contents/ui/config/Compact.qml:506
+#: src/contents/ui/config/Compact.qml:507
 #, kde-format
 msgid "Use album cover as icon should be checked for background to work."
 msgstr "Необхідно також увімкнути «Використовувати обкладинку як фон»."
 
-#: src/contents/ui/config/Compact.qml:517
+#: src/contents/ui/config/Compact.qml:518
 #, fuzzy, kde-format
 msgid "Background radius:"
 msgstr "Радіус кольорового фону:"
+
+#: src/contents/ui/config/Compact.qml:523
+#, kde-format
+msgid "Hover tooltip"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:528
+#, kde-format
+msgid "Hide player control keybinds in tooltip"
+msgstr ""
 
 #: src/contents/ui/config/ConfigIcon.qml:49
 #, kde-format
@@ -553,39 +563,39 @@ msgstr "Крок гучності:"
 msgid "Choose a Font"
 msgstr "Вибір шрифта"
 
-#: src/contents/ui/main.qml:23
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "Нічого не грає"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "від %1 (%2)"
 
-#: src/contents/ui/main.qml:26
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "СКМ: Призупинити"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "СКМ: Відтворити"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "Колесико миші: Зміна гучності"
 
-#: src/contents/ui/main.qml:29
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+Клац: Сфокусувати програвач"


### PR DESCRIPTION
Added a feature someone requested in #283. The option simply hides the keybindings for the media control from the hover tooltip of the panel view.