### PR TITLE
Add support for synced lyrics to full view

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ PlasMusic Toolbar is a widget for KDE Plasma 6 that shows currently playing song
 - **Panel song/icon/controls visibility:** Choose whether to show icon, song text and playback controls in the panel view.
 - **Preferred source**: Change the widget preferred source for music information (choose between active MPRIS2 sources).
 - **Song text customization**: Customize the maximum (or fixed) text width and scrolling behavior with adjustable scroll speed.
+- **Synced lyrics**: Optionally enable a Full View lyrics button. Opening lyrics sends the current track title, artist, album, and duration to [LRCLIB](https://lrclib.net/).
 - and more...
 
 
@@ -175,4 +176,3 @@ The widget comes with a helper script (`bin/i18n`) to manage translations:
   <img src="./screenshots/screenshot_vertical_1.png" />
   <img src="./screenshots/screenshot_vertical_2.png" />
 <p>
-

--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -144,6 +144,9 @@
         <entry name="fullViewLoopVisible" type="Bool">
             <default>true</default>
         </entry>
+        <entry name="fullViewLyricsEnabled" type="Bool">
+            <default>false</default>
+        </entry>
         <entry name="fullViewPlaybackControlsFillWidth" type="Bool">
             <default>true</default>
         </entry>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -25,11 +25,20 @@ Item {
     property bool songTextVisible: plasmoid.configuration.fullViewSongTextVisible
     property int songTextAlignment: plasmoid.configuration.fullViewSongTextAlignment
     property bool songTextAboveProgressBar: plasmoid.configuration.fullViewSongTextPosition === SongAndArtistText.VerticalPosition.AboveProgressBar
+    property bool lyricsEnabled: plasmoid.configuration.fullViewLyricsEnabled
 
     property bool showLyrics: false
+    readonly property bool canRequestLyrics: lyricsEnabled && player.title.length > 0 && player.artists.length > 0
+
+    onCanRequestLyricsChanged: {
+        if (!canRequestLyrics) {
+            showLyrics = false
+        }
+    }
 
     LyricsManager {
         id: lyricsManager
+        enabled: showLyrics && canRequestLyrics
         title: player.title
         artists: player.artists
         album: player.album
@@ -268,7 +277,7 @@ Item {
         }
 
         Item {
-            visible: shuffleVisible || playbackControlsVisible || loopVisible || lyricsManager.available
+            visible: shuffleVisible || playbackControlsVisible || loopVisible || canRequestLyrics
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.bottomMargin: 10
@@ -338,7 +347,7 @@ Item {
                 }
 
                 CommandIcon {
-                    visible: lyricsManager.available
+                    visible: canRequestLyrics
                     Layout.alignment: Qt.AlignHCenter
                     size: Kirigami.Units.iconSizes.medium
                     source: "view-media-lyrics"

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -26,6 +26,16 @@ Item {
     property int songTextAlignment: plasmoid.configuration.fullViewSongTextAlignment
     property bool songTextAboveProgressBar: plasmoid.configuration.fullViewSongTextPosition === SongAndArtistText.VerticalPosition.AboveProgressBar
 
+    property bool showLyrics: false
+
+    LyricsManager {
+        id: lyricsManager
+        title: player.title
+        artists: player.artists
+        album: player.album
+        songLength: player.songLength
+    }
+
     // The Full View max and min width is driven by config values. The window can be resized within these bounds; thumbnail and text adapt.
     readonly property int configMinWidth: plasmoid.configuration.fullViewMinWidth
     readonly property int maximumWidth: plasmoid.configuration.fullViewMaxWidth
@@ -121,7 +131,7 @@ Item {
 
         Rectangle {
             id: thumbnailContainer
-            visible: thumbnailVisible
+            visible: thumbnailVisible && !showLyrics
             Layout.fillWidth: true
             Layout.margins: 10
             // Use the actual image aspect ratio, fallback to square if not loaded yet
@@ -169,6 +179,18 @@ Item {
 					}
 				}
             }
+        }
+
+        LyricsView {
+            visible: showLyrics
+            Layout.fillWidth: true
+            Layout.margins: 10
+            Layout.preferredHeight: showLyrics ? width / (albumArtNormal.implicitWidth > 0 && albumArtNormal.implicitHeight > 0
+                ? albumArtNormal.implicitWidth / albumArtNormal.implicitHeight : 1.0) : 0
+            lyrics: lyricsManager.lyrics
+            songPosition: player.songPosition
+            textFont: baseFont
+            loading: lyricsManager.loading
         }
 
         SongAndArtistText {
@@ -246,7 +268,7 @@ Item {
         }
 
         Item {
-            visible: shuffleVisible || playbackControlsVisible || loopVisible
+            visible: shuffleVisible || playbackControlsVisible || loopVisible || lyricsManager.available
             Layout.leftMargin: 20
             Layout.rightMargin: 20
             Layout.bottomMargin: 10
@@ -313,6 +335,15 @@ Item {
                             status = Mpris.LoopStatus.Playlist;
                         player.setLoopStatus(status);
                     }
+                }
+
+                CommandIcon {
+                    visible: lyricsManager.available
+                    Layout.alignment: Qt.AlignHCenter
+                    size: Kirigami.Units.iconSizes.medium
+                    source: "view-media-lyrics"
+                    active: showLyrics
+                    onClicked: showLyrics = !showLyrics
                 }
 
             }

--- a/src/contents/ui/LyricsManager.qml
+++ b/src/contents/ui/LyricsManager.qml
@@ -7,6 +7,7 @@ QtObject {
     property string artists: ""
     property string album: ""
     property double songLength: 0  // microseconds
+    property bool enabled: false
 
     property var lyrics: []
     property bool loading: false
@@ -14,6 +15,8 @@ QtObject {
 
     // Internal: track what we last fetched to avoid duplicate requests
     property string _lastQuery: ""
+    property int _requestId: 0
+    property var _activeRequest: null
 
     // Debounce timer to avoid spamming API on rapid track changes
     property var _debounceTimer: Timer {
@@ -22,19 +25,25 @@ QtObject {
         onTriggered: root._fetchLyrics()
     }
 
+    onEnabledChanged: _scheduleRefetch()
     onTitleChanged: _scheduleRefetch()
     onArtistsChanged: _scheduleRefetch()
+    onAlbumChanged: _scheduleRefetch()
+    onSongLengthChanged: _scheduleRefetch()
 
     function _scheduleRefetch() {
-        const query = title + "|" + artists
-        if (query === _lastQuery) return
-        if (!title || !artists) {
-            _lastQuery = ""
-            lyrics = []
-            available = false
-            loading = false
+        if (!enabled) {
+            _clear()
             return
         }
+
+        const query = _queryKey()
+        if (query === _lastQuery) return
+        if (!title || !artists) {
+            _clear()
+            return
+        }
+        _abortActiveRequest()
         _lastQuery = query
         lyrics = []
         available = false
@@ -42,11 +51,48 @@ QtObject {
         _debounceTimer.restart()
     }
 
+    function _clear() {
+        _debounceTimer.stop()
+        _abortActiveRequest()
+        _lastQuery = ""
+        lyrics = []
+        available = false
+        loading = false
+    }
+
+    function _abortActiveRequest() {
+        _requestId++
+        if (_activeRequest) {
+            const xhr = _activeRequest
+            _activeRequest = null
+            xhr.onreadystatechange = function() {}
+            xhr.abort()
+        }
+    }
+
+    function _queryKey() {
+        const durationSec = Math.round(songLength / 1000000)
+        return JSON.stringify([title, artists, album, durationSec])
+    }
+
+    function _isCurrentRequest(requestId, query) {
+        return enabled && requestId === _requestId && query === _lastQuery
+    }
+
     function _fetchLyrics() {
+        if (!enabled || !title || !artists) {
+            _clear()
+            return
+        }
+
+        _abortActiveRequest()
+
         const trackName = encodeURIComponent(title)
         const artistName = encodeURIComponent(artists)
         const albumName = encodeURIComponent(album)
         const durationSec = Math.round(songLength / 1000000)
+        const query = _lastQuery
+        const requestId = _requestId
 
         let url = "https://lrclib.net/api/get?artist_name=" + artistName
             + "&track_name=" + trackName
@@ -56,13 +102,19 @@ QtObject {
         }
 
         const xhr = new XMLHttpRequest()
+        _activeRequest = xhr
         xhr.onreadystatechange = function() {
             if (xhr.readyState !== XMLHttpRequest.DONE) return
+            if (!_isCurrentRequest(requestId, query)) return
+
+            if (_activeRequest === xhr) {
+                _activeRequest = null
+            }
 
             if (xhr.status === 200) {
-                _handleResponse(xhr.responseText)
+                _handleResponse(xhr.responseText, requestId, query)
             } else if (xhr.status === 404) {
-                _searchLyrics()
+                _searchLyrics(requestId, query)
             } else {
                 loading = false
             }
@@ -72,15 +124,23 @@ QtObject {
         xhr.send()
     }
 
-    function _searchLyrics() {
+    function _searchLyrics(requestId, query) {
+        if (!_isCurrentRequest(requestId, query)) return
+
         const trackName = encodeURIComponent(title)
         const artistName = encodeURIComponent(artists)
         const url = "https://lrclib.net/api/search?track_name=" + trackName
             + "&artist_name=" + artistName
 
         const xhr = new XMLHttpRequest()
+        _activeRequest = xhr
         xhr.onreadystatechange = function() {
             if (xhr.readyState !== XMLHttpRequest.DONE) return
+            if (!_isCurrentRequest(requestId, query)) return
+
+            if (_activeRequest === xhr) {
+                _activeRequest = null
+            }
 
             if (xhr.status === 200) {
                 try {
@@ -105,7 +165,9 @@ QtObject {
         xhr.send()
     }
 
-    function _handleResponse(responseText) {
+    function _handleResponse(responseText, requestId, query) {
+        if (!_isCurrentRequest(requestId, query)) return
+
         try {
             const data = JSON.parse(responseText)
             if (data.syncedLyrics) {

--- a/src/contents/ui/LyricsManager.qml
+++ b/src/contents/ui/LyricsManager.qml
@@ -1,0 +1,143 @@
+import QtQuick
+
+QtObject {
+    id: root
+
+    property string title: ""
+    property string artists: ""
+    property string album: ""
+    property double songLength: 0  // microseconds
+
+    property var lyrics: []
+    property bool loading: false
+    property bool available: false
+
+    // Internal: track what we last fetched to avoid duplicate requests
+    property string _lastQuery: ""
+
+    // Debounce timer to avoid spamming API on rapid track changes
+    property var _debounceTimer: Timer {
+        interval: 300
+        repeat: false
+        onTriggered: root._fetchLyrics()
+    }
+
+    onTitleChanged: _scheduleRefetch()
+    onArtistsChanged: _scheduleRefetch()
+
+    function _scheduleRefetch() {
+        const query = title + "|" + artists
+        if (query === _lastQuery) return
+        if (!title || !artists) {
+            _lastQuery = ""
+            lyrics = []
+            available = false
+            loading = false
+            return
+        }
+        _lastQuery = query
+        lyrics = []
+        available = false
+        loading = true
+        _debounceTimer.restart()
+    }
+
+    function _fetchLyrics() {
+        const trackName = encodeURIComponent(title)
+        const artistName = encodeURIComponent(artists)
+        const albumName = encodeURIComponent(album)
+        const durationSec = Math.round(songLength / 1000000)
+
+        let url = "https://lrclib.net/api/get?artist_name=" + artistName
+            + "&track_name=" + trackName
+            + "&album_name=" + albumName
+        if (durationSec > 0) {
+            url += "&duration=" + durationSec
+        }
+
+        const xhr = new XMLHttpRequest()
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState !== XMLHttpRequest.DONE) return
+
+            if (xhr.status === 200) {
+                _handleResponse(xhr.responseText)
+            } else if (xhr.status === 404) {
+                _searchLyrics()
+            } else {
+                loading = false
+            }
+        }
+        xhr.open("GET", url)
+        xhr.setRequestHeader("User-Agent", "PlasMusic Toolbar (https://github.com/ccatterina/plasmusic-toolbar)")
+        xhr.send()
+    }
+
+    function _searchLyrics() {
+        const trackName = encodeURIComponent(title)
+        const artistName = encodeURIComponent(artists)
+        const url = "https://lrclib.net/api/search?track_name=" + trackName
+            + "&artist_name=" + artistName
+
+        const xhr = new XMLHttpRequest()
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState !== XMLHttpRequest.DONE) return
+
+            if (xhr.status === 200) {
+                try {
+                    const results = JSON.parse(xhr.responseText)
+                    for (let i = 0; i < results.length; i++) {
+                        if (results[i].syncedLyrics) {
+                            lyrics = _parseLRC(results[i].syncedLyrics)
+                            available = lyrics.length > 0
+                            loading = false
+                            return
+                        }
+                    }
+                } catch (e) {
+                    // parse error, fall through
+                }
+            }
+            loading = false
+            available = false
+        }
+        xhr.open("GET", url)
+        xhr.setRequestHeader("User-Agent", "PlasMusic Toolbar (https://github.com/ccatterina/plasmusic-toolbar)")
+        xhr.send()
+    }
+
+    function _handleResponse(responseText) {
+        try {
+            const data = JSON.parse(responseText)
+            if (data.syncedLyrics) {
+                lyrics = _parseLRC(data.syncedLyrics)
+                available = lyrics.length > 0
+            } else {
+                available = false
+            }
+        } catch (e) {
+            available = false
+        }
+        loading = false
+    }
+
+    function _parseLRC(lrcString) {
+        const lines = lrcString.split('\n')
+        const result = []
+        for (let i = 0; i < lines.length; i++) {
+            const match = lines[i].match(/\[(\d{2}):(\d{2})\.(\d{2,3})\]\s*(.*)/)
+            if (match) {
+                const minutes = parseInt(match[1])
+                const seconds = parseInt(match[2])
+                const ms = match[3].length === 2
+                    ? parseInt(match[3]) * 10
+                    : parseInt(match[3])
+                const timeMs = minutes * 60000 + seconds * 1000 + ms
+                const text = match[4].trim()
+                if (text.length > 0) {
+                    result.push({time: timeMs, text: text})
+                }
+            }
+        }
+        return result
+    }
+}

--- a/src/contents/ui/LyricsView.qml
+++ b/src/contents/ui/LyricsView.qml
@@ -1,0 +1,120 @@
+import QtQuick
+import QtQuick.Layouts
+import org.kde.plasma.components as PlasmaComponents3
+import org.kde.kirigami as Kirigami
+
+Item {
+    id: root
+
+    property var lyrics: []
+    property double songPosition: 0  // microseconds
+    property font textFont: Kirigami.Theme.defaultFont
+    property bool loading: false
+
+    Layout.fillWidth: true
+
+    property int _currentLyricIndex: 0
+
+    function findCurrentIndex() {
+        if (!lyrics || lyrics.length === 0) return 0
+        const posMs = songPosition / 1000
+        const cur = _currentLyricIndex
+
+        // Normal playback: check if we're still on the current line or moved to the next
+        if (cur < lyrics.length && lyrics[cur].time <= posMs) {
+            if (cur + 1 >= lyrics.length || lyrics[cur + 1].time > posMs) {
+                return cur
+            }
+            if (cur + 2 >= lyrics.length || lyrics[cur + 2].time > posMs) {
+                return cur + 1
+            }
+        }
+
+        // Seek or large jump: fall back to reverse linear scan
+        for (let i = lyrics.length - 1; i >= 0; i--) {
+            if (lyrics[i].time <= posMs) return i
+        }
+        return 0
+    }
+
+    onSongPositionChanged: {
+        if (!lyrics || lyrics.length === 0) return
+        const idx = findCurrentIndex()
+        if (idx !== _currentLyricIndex) {
+            _currentLyricIndex = idx
+        }
+    }
+
+    onLyricsChanged: {
+        _currentLyricIndex = 0
+    }
+
+    PlasmaComponents3.BusyIndicator {
+        anchors.centerIn: parent
+        visible: root.loading
+        running: visible
+    }
+
+    PlasmaComponents3.Label {
+        anchors.centerIn: parent
+        visible: !root.loading && (!root.lyrics || root.lyrics.length === 0)
+        text: i18n("No synced lyrics available")
+        opacity: 0.6
+        font: root.textFont
+        color: Kirigami.Theme.textColor
+    }
+
+    ListView {
+        id: lyricsListView
+        anchors.fill: parent
+        visible: !root.loading && root.lyrics && root.lyrics.length > 0
+        model: root.lyrics
+        clip: true
+        interactive: true
+        currentIndex: root._currentLyricIndex
+        cacheBuffer: 2000
+
+        preferredHighlightBegin: height / 2 - 30
+        preferredHighlightEnd: height / 2 + 30
+        highlightRangeMode: ListView.StrictlyEnforceRange
+        highlightMoveDuration: 500
+        highlightMoveVelocity: -1
+
+        highlight: Item {}
+
+        delegate: Item {
+            width: lyricsListView.width
+            height: lyricLabel.implicitHeight + Kirigami.Units.smallSpacing * 2
+
+            required property int index
+            required property var modelData
+
+            readonly property bool isActive: index === lyricsListView.currentIndex
+
+            PlasmaComponents3.Label {
+                id: lyricLabel
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.verticalCenter: parent.verticalCenter
+                anchors.leftMargin: Kirigami.Units.largeSpacing
+                anchors.rightMargin: Kirigami.Units.largeSpacing
+
+                text: modelData.text
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WordWrap
+                color: Kirigami.Theme.textColor
+                font.family: root.textFont.family
+                font.pointSize: parent.isActive
+                    ? root.textFont.pointSize * 1.1
+                    : root.textFont.pointSize
+                font.bold: parent.isActive
+
+                opacity: parent.isActive ? 1.0 : 0.35
+
+                Behavior on opacity {
+                    NumberAnimation { duration: 350; easing.type: Easing.OutCubic }
+                }
+            }
+        }
+    }
+}

--- a/src/contents/ui/LyricsView.qml
+++ b/src/contents/ui/LyricsView.qml
@@ -9,6 +9,7 @@ Item {
     property var lyrics: []
     property double songPosition: 0  // microseconds
     property font textFont: Kirigami.Theme.defaultFont
+    property font activeTextFont: Qt.font(Object.assign({}, textFont, {weight: Font.Bold}))
     property bool loading: false
 
     Layout.fillWidth: true
@@ -46,7 +47,7 @@ Item {
     }
 
     onLyricsChanged: {
-        _currentLyricIndex = 0
+        _currentLyricIndex = findCurrentIndex()
     }
 
     PlasmaComponents3.BusyIndicator {
@@ -103,11 +104,7 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 wrapMode: Text.WordWrap
                 color: Kirigami.Theme.textColor
-                font.family: root.textFont.family
-                font.pointSize: parent.isActive
-                    ? root.textFont.pointSize * 1.1
-                    : root.textFont.pointSize
-                font.bold: parent.isActive
+                font: parent.isActive ? root.activeTextFont : root.textFont
 
                 opacity: parent.isActive ? 1.0 : 0.35
 

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -26,6 +26,7 @@ KCM.SimpleKCM {
     property alias cfg_fullViewShuffleVisible: fullViewShuffleVisible.checked
     property alias cfg_fullViewPlaybackControlsVisible: fullViewPlaybackControlsVisible.checked
     property alias cfg_fullViewLoopVisible: fullViewLoopVisible.checked
+    property alias cfg_fullViewLyricsEnabled: fullViewLyricsEnabled.checked
     property alias cfg_fullViewPlaybackControlsFillWidth: fullViewPlaybackControlsFillWidth.checked
     property alias cfg_fullViewSongTextVisible: fullViewSongTextVisible.checked
     property alias cfg_fullViewSongTextAlignment: fullViewSongTextAlignment.value
@@ -148,6 +149,18 @@ KCM.SimpleKCM {
         CheckBox {
             id: fullViewLoopVisible
             Kirigami.FormData.label: i18n("Show loop control")
+        }
+
+        RowLayout {
+            Kirigami.FormData.label: i18n("Show synced lyrics")
+            CheckBox {
+                id: fullViewLyricsEnabled
+            }
+            Kirigami.ContextualHelpButton {
+                toolTipText: i18n(
+                    "When enabled, the lyrics button appears in Full View. Opening lyrics sends the current track title, artist, album, and duration to LRCLIB."
+                )
+            }
         }
 
         RowLayout {

--- a/src/translate/fr.po
+++ b/src/translate/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: 2026-02-23 00:22+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,17 +32,22 @@ msgstr "Vue panneau"
 msgid "Full View"
 msgstr "Vue complète"
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Mettre le lecteur au premier plan"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Ce lecteur ne peut pas être mis au premier plan"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr "Aucune parole synchronisée disponible"
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr "Disposition"
@@ -65,7 +70,7 @@ msgstr ""
 "haut) et les contrôles de lecture sont alignés à droite (ou en bas) ; le "
 "texte de la chanson peut être positionné selon les préférences."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Alignement du texte :"
@@ -75,7 +80,7 @@ msgstr "Alignement du texte :"
 msgid "Left (Top for vertical panel)"
 msgstr "Gauche (Haut pour panneau vertical)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr "Centre"
@@ -90,7 +95,7 @@ msgstr "Droite (Bas pour panneau vertical)"
 msgid "Show icon:"
 msgstr "Afficher l'icône :"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr "Afficher le texte de la chanson"
@@ -136,7 +141,7 @@ msgstr "Utiliser la pochette comme icône"
 msgid "Fallback to icon if cover is not available"
 msgstr "Revenir à l'icône si la pochette n'est pas disponible"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrondi de la pochette :"
@@ -146,51 +151,51 @@ msgstr "Arrondi de la pochette :"
 msgid "Song text customization"
 msgstr "Personnalisation du texte du titre"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr "Position du titre :"
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr "Caché"
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr "Première ligne"
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr "Deuxième ligne"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr "Position de l'artiste :"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr "Position du titre d'album :"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -238,7 +243,7 @@ msgstr "Fondu"
 msgid "None"
 msgstr "Aucun"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr "Défilement du texte"
@@ -248,7 +253,7 @@ msgstr "Défilement du texte"
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr "Vitesse :"
@@ -293,7 +298,7 @@ msgstr "Personnalisation des contrôles de lecture"
 msgid "Space between controls"
 msgstr "Espace entre les contrôles"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr "Fond"
@@ -332,67 +337,82 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Effacer l'icône"
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, kde-format
 msgid "Show album cover"
 msgstr "Afficher la pochette"
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr "Gauche"
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr "Droite"
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, kde-format
 msgid "Song text position:"
 msgstr "Position du texte :"
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr "Au-dessus de la barre de progression"
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr "Sous la barre de progression"
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, kde-format
 msgid "Show volume control"
 msgstr "Afficher le contrôle de volume"
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Afficher le contrôle de lecture aléatoire"
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, kde-format
 msgid "Show playback controls"
 msgstr "Afficher les contrôles de lecture"
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, kde-format
 msgid "Show loop control"
 msgstr "Afficher le contrôle de répétition"
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr "Afficher les paroles synchronisées"
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+"Lorsqu'elle est activée, le bouton des paroles apparaît dans la vue "
+"complète. L'ouverture des paroles envoie le titre, l'artiste, l'album et la "
+"durée du morceau actuel à LRCLIB."
+
+#: src/contents/ui/config/Full.qml:167
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Les contrôles de lecture remplissent l'espace disponible"
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -401,72 +421,72 @@ msgstr ""
 "Lorsqu'activé, les contrôles de lecture sont répartis sur toute la largeur "
 "du widget. Lorsque désactivé, ils sont regroupés au centre."
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Largeur minimale redimensionnable :"
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Largeur maximale redimensionnable :"
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr "Pochette d'album"
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Image de remplacement :"
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Choisir…"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, kde-format
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, fuzzy, kde-format
 msgid "Round album cover"
 msgstr "Pochette d'album arrondie"
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personnalisation du texte"
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Fond (widget bureau uniquement) :"
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr "Standard"
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr "Transparent"
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Transparent (contenu ombré)"
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Utiliser la pochette comme fond"
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Fonctionnalité expérimentale)"

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,17 +32,22 @@ msgstr "Vista pannello"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr "Nessun testo sincronizzato disponibile"
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr "Disposizione"
@@ -66,7 +71,7 @@ msgstr ""
 "il testo della canzone può essere posizionato in base alle preferenze "
 "dell'utente."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Allineamento brano:"
@@ -76,7 +81,7 @@ msgstr "Allineamento brano:"
 msgid "Left (Top for vertical panel)"
 msgstr "Sinistra (Alto per pannello verticale)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr "Centro"
@@ -91,7 +96,7 @@ msgstr "Destra (Basso per pannello verticale)"
 msgid "Show icon:"
 msgstr "Mostra icona:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr "Mostra brano"
@@ -137,7 +142,7 @@ msgstr "Usa copertina album come icona"
 msgid "Fallback to icon if cover is not available"
 msgstr "Usa icona se la copertina non è disponibile"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrotondamento bordo copertina album:"
@@ -147,51 +152,51 @@ msgstr "Arrotondamento bordo copertina album:"
 msgid "Song text customization"
 msgstr "Personalizzazione testo brano"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr "Posizionamento titolo:"
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr "Nascosto"
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr "Prima riga"
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr "Seconda riga"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr "Posizione artista/i:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr "Posizione titolo album:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -237,7 +242,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr "Scorrimento testo"
@@ -247,7 +252,7 @@ msgstr "Scorrimento testo"
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr "Velocità:"
@@ -292,7 +297,7 @@ msgstr "Personalizzazione comandi di riproduzione"
 msgid "Space between controls"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr "Sfondo"
@@ -331,139 +336,154 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Resetta icona"
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, fuzzy, kde-format
 msgid "Show album cover"
 msgstr "Copertina album"
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, fuzzy, kde-format
 msgid "Song text position:"
 msgstr "Posizionamento titolo:"
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, fuzzy, kde-format
 msgid "Show volume control"
 msgstr "Mostra comando riproduci/pausa"
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, fuzzy, kde-format
 msgid "Show shuffle control"
 msgstr "Mostra comando riproduci/pausa"
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, fuzzy, kde-format
 msgid "Show playback controls"
 msgstr "Mostra comando riproduci/pausa"
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, fuzzy, kde-format
 msgid "Show loop control"
 msgstr "Mostra comando riproduci/pausa"
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr "Mostra testi sincronizzati"
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+"Quando è abilitata, il pulsante dei testi appare nella vista completa. "
+"L'apertura dei testi invia il titolo, l'artista, l'album e la durata della "
+"traccia corrente a LRCLIB."
+
+#: src/contents/ui/config/Full.qml:167
 #, fuzzy, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Riempi lo spazio disponibile nel pannello"
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr "Copertina album"
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Immagine placeholder per album:"
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Scegli…"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, fuzzy, kde-format
 msgid "Clear"
 msgstr "Resetta icona"
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, fuzzy, kde-format
 msgid "Round album cover"
 msgstr "Copertina album"
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personalizzazione testo canzone"
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Sfondo (solo per widget desktop):"
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr "Standard"
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr "Trasparente"
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Trasparente (Ombra)"
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Usa copertina album come sfondo"
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "Funzionalità sperimentale"

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: 2026-03-15 10:48+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -33,17 +33,22 @@ msgstr "Paneelweergave"
 msgid "Full View"
 msgstr "Volledige weergave"
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr "Geen gesynchroniseerde songteksten beschikbaar"
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr "Indeling"
@@ -66,7 +71,7 @@ msgstr ""
 "bovenaan uitgelijnd, en de afspeelbediening rechts of onderaan. De tekst kan "
 "op een locatie naar keuze worden getoond."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Tekst uitlijnen:"
@@ -76,7 +81,7 @@ msgstr "Tekst uitlijnen:"
 msgid "Left (Top for vertical panel)"
 msgstr "Links/Bovenaan"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr "Midden"
@@ -91,7 +96,7 @@ msgstr "Rechts/Onderaan"
 msgid "Show icon:"
 msgstr "Pictogram tonen:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr "Titel van nummer tonen"
@@ -139,7 +144,7 @@ msgstr ""
 "Indien er geen hoes beschikbaar is, zal het standaardpictogram worden "
 "gebruikt"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albumhoesafmetingen:"
@@ -149,51 +154,51 @@ msgstr "Albumhoesafmetingen:"
 msgid "Song text customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr "Tekstlocatie:"
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr "Verborgen"
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr "Eerste regel"
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr "Tweede regel"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr "Artiestlocatie:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr "Albumtitellocatie:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Albumnaam verbergen indien gelijk aan single:"
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -241,7 +246,7 @@ msgstr "Vervaging"
 msgid "None"
 msgstr "Geen"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr "Tekst laten verschuiven"
@@ -251,7 +256,7 @@ msgstr "Tekst laten verschuiven"
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr "Snelheid:"
@@ -296,7 +301,7 @@ msgstr "Afspeelbediening aanpassen"
 msgid "Space between controls"
 msgstr "Ruimte tussen bedieningsknoppen"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr "Achtergrond"
@@ -335,67 +340,82 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Pictogram wissen"
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, kde-format
 msgid "Show album cover"
 msgstr "Albumhoes tonen"
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr "Voortgangsbalk tonen"
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr "Links"
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr "Rechts"
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, kde-format
 msgid "Song text position:"
 msgstr "Songtekstlocatie:"
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr "Boven voortgangsbalk"
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr "Onder voortgangsbalk"
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, kde-format
 msgid "Show volume control"
 msgstr "Volumeregeling tonen"
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Knoppen voor willekeurig afspelen tonen"
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, kde-format
 msgid "Show playback controls"
 msgstr "Afspeelbediening tonen"
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, kde-format
 msgid "Show loop control"
 msgstr "Knoppen voor herhalen tonen"
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr "Gesynchroniseerde songteksten tonen"
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+"Wanneer ingeschakeld, verschijnt de knop voor songteksten in de volledige "
+"weergave. Bij het openen van songteksten worden de huidige tracktitel, "
+"artiest, album en duur naar LRCLIB verzonden."
+
+#: src/contents/ui/config/Full.qml:167
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Alle beschikbare paneelruimte gebruiken voor afspeelbediening"
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -404,72 +424,72 @@ msgstr ""
 "Schakel in om de afspeelbediening over de gehele breedte van de widget te "
 "tonen. Schakel uit om in het midden te groeperen."
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Minimale aanpasbare breedte:"
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Maximale aanpasbare breedte:"
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr "Albumhoes"
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Plaatshouder van albumhoes:"
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Kiezen…"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, kde-format
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, kde-format
 msgid "Round album cover"
 msgstr "Albumhoezen voorzien van afgeronde hoeken"
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Achtergrond (alleen bureaubladwidget):"
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr "Standaard"
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr "Doorzichtig"
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Doorzichtig, met schaduw"
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Albumhoes gebruiken als achtergrond"
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Experimentele functionaliteit)"

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,17 +32,22 @@ msgstr ""
 msgid "Full View"
 msgstr ""
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr ""
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr ""
@@ -61,7 +66,7 @@ msgid ""
 "positioned based on user preference."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr ""
@@ -71,7 +76,7 @@ msgstr ""
 msgid "Left (Top for vertical panel)"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr ""
@@ -86,7 +91,7 @@ msgstr ""
 msgid "Show icon:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr ""
@@ -132,7 +137,7 @@ msgstr ""
 msgid "Fallback to icon if cover is not available"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr ""
@@ -142,51 +147,51 @@ msgstr ""
 msgid "Song text customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -232,7 +237,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr ""
@@ -242,7 +247,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr ""
@@ -287,7 +292,7 @@ msgstr ""
 msgid "Space between controls"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr ""
@@ -324,139 +329,151 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, kde-format
 msgid "Show album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, kde-format
 msgid "Song text position:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, kde-format
 msgid "Show volume control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, kde-format
 msgid "Show shuffle control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, kde-format
 msgid "Show playback controls"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, kde-format
 msgid "Show loop control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:167
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, kde-format
 msgid "Clear"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, kde-format
 msgid "Round album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr ""

--- a/src/translate/tr.po
+++ b/src/translate/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: 2026-03-08 00:00+0300\n"
 "Last-Translator: A coffee lover\n"
 "Language-Team: none\n"
@@ -32,17 +32,22 @@ msgstr "Panel Görünümü"
 msgid "Full View"
 msgstr "Tam Görünüm"
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Oynatıcıyı öne getir"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Bu oynatıcı öne getirilemez"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr "Senkronize şarkı sözleri yok"
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr "Yerleşim"
@@ -65,7 +70,7 @@ msgstr ""
 "kontrolleri sağa (veya alta) hizalanır; şarkı metni kullanıcı tercihine göre "
 "konumlandırılabilir."
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Şarkı metni hizalaması:"
@@ -75,7 +80,7 @@ msgstr "Şarkı metni hizalaması:"
 msgid "Left (Top for vertical panel)"
 msgstr "Sol (Dikey panel için üst)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr "Orta"
@@ -90,7 +95,7 @@ msgstr "Sağ (Dikey panel için alt)"
 msgid "Show icon:"
 msgstr "Simgeyi göster:"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr "Şarkı metnini göster"
@@ -136,7 +141,7 @@ msgstr "Albüm kapağını simge olarak kullan"
 msgid "Fallback to icon if cover is not available"
 msgstr "Kapak yoksa yerine simgeyi kullan"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albüm kapağı köşe yarıçapı:"
@@ -146,56 +151,55 @@ msgstr "Albüm kapağı köşe yarıçapı:"
 msgid "Song text customization"
 msgstr "Şarkı metni özelleştirme"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr "Şarkı adı konumu:"
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr "Gizli"
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr "İlk satır"
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr "İkinci satır"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr "Sanatçıların konumu:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr "Albüm adı konumu:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Tekli parçalarda albüm adını gizle:"
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
-msgstr ""
-"Albüm adı ve parça başlığı eşleşirse albüm adı gizlenecektir."
+msgstr "Albüm adı ve parça başlığı eşleşirse albüm adı gizlenecektir."
 
 #: src/contents/ui/config/Compact.qml:326
 #, kde-format
@@ -237,7 +241,7 @@ msgstr "Soldur"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr "Metin kaydırma"
@@ -247,7 +251,7 @@ msgstr "Metin kaydırma"
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr "Hız:"
@@ -292,7 +296,7 @@ msgstr "Oynatma kontrolleri özelleştirme"
 msgid "Space between controls"
 msgstr "Kontroller arası boşluk"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr "Arka plan"
@@ -331,67 +335,82 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Simgeyi Temizle"
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, kde-format
 msgid "Show album cover"
 msgstr "Albüm kapağını göster"
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr "İlerleme çubuğunu göster"
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr "Sol"
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr "Sağ"
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, kde-format
 msgid "Song text position:"
 msgstr "Şarkı metni konumu:"
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr "İlerleme çubuğunun üstünde"
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr "İlerleme çubuğunun altında"
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, kde-format
 msgid "Show volume control"
 msgstr "Ses düzeyi kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Karıştırma kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, kde-format
 msgid "Show playback controls"
 msgstr "Oynatma kontrollerini göster"
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, kde-format
 msgid "Show loop control"
 msgstr "Döngü kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr "Senkronize şarkı sözlerini göster"
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+"Etkinleştirildiğinde, Tam Görünümde şarkı sözleri düğmesi görünür. Şarkı "
+"sözlerini açmak, geçerli parçanın başlığını, sanatçısını, albümünü ve "
+"süresini LRCLIB'e gönderir."
+
+#: src/contents/ui/config/Full.qml:167
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Kullanılabilir alanı oynatma kontrolleriyle doldur"
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -400,72 +419,72 @@ msgstr ""
 "Etkinleştirildiğinde, oynatma kontrolleri araç takımının tüm genişliğine "
 "yayılır. Devre dışı bırakıldığında ortada gruplandırılır."
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Minimum boyutlandırılabilir genişlik:"
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Maksimum boyutlandırılabilir genişlik:"
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr "Albüm kapağı"
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Albüm yer tutucusu:"
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Seç…"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, kde-format
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, kde-format
 msgid "Round album cover"
 msgstr "Yuvarlak albüm kapağı"
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Şarkı metni özelleştirme"
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Arka plan (yalnızca masaüstü araç takımı):"
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr "Standart"
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr "Saydam"
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Saydam (Gölgeli içerik)"
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Albüm kapağını arka plan olarak kullan"
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Deneysel özellik)"

--- a/src/translate/uk.po
+++ b/src/translate/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-06 06:44+0300\n"
+"POT-Creation-Date: 2026-04-11 12:07+0200\n"
 "PO-Revision-Date: 2025-09-30 01:49+0200\n"
 "Last-Translator: Vsevolod «Damglador» Stopchanskyi "
 "<vse.stopchanskyi@gmail.com>\n"
@@ -33,17 +33,22 @@ msgstr "Панельний показ"
 msgid "Full View"
 msgstr "Повний показ"
 
-#: src/contents/ui/Full.qml:137
+#: src/contents/ui/Full.qml:156
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Сфокусувати програвач"
 
-#: src/contents/ui/Full.qml:137 src/contents/ui/main.qml:29
+#: src/contents/ui/Full.qml:156 src/contents/ui/main.qml:29
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Цей програвач неможливо сфокусувати"
 
-#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:43
+#: src/contents/ui/LyricsView.qml:62
+#, kde-format
+msgid "No synced lyrics available"
+msgstr "Синхронізовані тексти недоступні"
+
+#: src/contents/ui/config/Compact.qml:49 src/contents/ui/config/Full.qml:44
 #, kde-format
 msgid "Layout"
 msgstr "Компонування"
@@ -65,7 +70,7 @@ msgstr ""
 "піктограмою ліворуч чи зверху та елементами керування праворуч чи унизу. "
 "Опис композиції може бути розташований за побажанням. "
 
-#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:62
+#: src/contents/ui/config/Compact.qml:70 src/contents/ui/config/Full.qml:63
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Розташування опису композиції"
@@ -75,7 +80,7 @@ msgstr "Розташування опису композиції"
 msgid "Left (Top for vertical panel)"
 msgstr "Ліворуч (зверху для вертикальних панелей)"
 
-#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:75
+#: src/contents/ui/config/Compact.qml:82 src/contents/ui/config/Full.qml:76
 #, kde-format
 msgid "Center"
 msgstr "По центру"
@@ -90,7 +95,7 @@ msgstr "Праворуч (унизу для вертикальних панел�
 msgid "Show icon:"
 msgstr "Показувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:100
+#: src/contents/ui/config/Compact.qml:110 src/contents/ui/config/Full.qml:101
 #, kde-format
 msgid "Show song text"
 msgstr "Показувати опис композиції"
@@ -136,7 +141,7 @@ msgstr "Використовувати зображення альбому"
 msgid "Fallback to icon if cover is not available"
 msgstr "Інакше, використовувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:230
+#: src/contents/ui/config/Compact.qml:165 src/contents/ui/config/Full.qml:243
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Радіус зображення альбому:"
@@ -146,51 +151,51 @@ msgstr "Радіус зображення альбому:"
 msgid "Song text customization"
 msgstr "Налаштування опису композиції"
 
-#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:246
+#: src/contents/ui/config/Compact.qml:181 src/contents/ui/config/Full.qml:259
 #, kde-format
 msgid "Song title position:"
 msgstr "Позиція назви композиції:"
 
 #: src/contents/ui/config/Compact.qml:182
 #: src/contents/ui/config/Compact.qml:229
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:247
-#: src/contents/ui/config/Full.qml:294 src/contents/ui/config/Full.qml:339
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:260
+#: src/contents/ui/config/Full.qml:307 src/contents/ui/config/Full.qml:352
 #, kde-format
 msgid "Hidden"
 msgstr "Прихований"
 
 #: src/contents/ui/config/Compact.qml:193
 #: src/contents/ui/config/Compact.qml:240
-#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:258
-#: src/contents/ui/config/Full.qml:305 src/contents/ui/config/Full.qml:350
+#: src/contents/ui/config/Compact.qml:285 src/contents/ui/config/Full.qml:271
+#: src/contents/ui/config/Full.qml:318 src/contents/ui/config/Full.qml:363
 #, kde-format
 msgid "First line"
 msgstr "Перший ряд"
 
 #: src/contents/ui/config/Compact.qml:204
 #: src/contents/ui/config/Compact.qml:251
-#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:269
-#: src/contents/ui/config/Full.qml:316 src/contents/ui/config/Full.qml:361
+#: src/contents/ui/config/Compact.qml:296 src/contents/ui/config/Full.qml:282
+#: src/contents/ui/config/Full.qml:329 src/contents/ui/config/Full.qml:374
 #, kde-format
 msgid "Second line"
 msgstr "Другий ряд"
 
-#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:293
+#: src/contents/ui/config/Compact.qml:228 src/contents/ui/config/Full.qml:306
 #, kde-format
 msgid "Artists position:"
 msgstr "Позиція композитора:"
 
-#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:338
+#: src/contents/ui/config/Compact.qml:273 src/contents/ui/config/Full.qml:351
 #, kde-format
 msgid "Album title position:"
 msgstr "Позиція назви альбому:"
 
-#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:372
+#: src/contents/ui/config/Compact.qml:307 src/contents/ui/config/Full.qml:385
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:378
+#: src/contents/ui/config/Compact.qml:313 src/contents/ui/config/Full.qml:391
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -236,7 +241,7 @@ msgstr "Згасання"
 msgid "None"
 msgstr "Немає"
 
-#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:385
+#: src/contents/ui/config/Compact.qml:395 src/contents/ui/config/Full.qml:398
 #, kde-format
 msgid "Text scrolling"
 msgstr "Прокручування тексту"
@@ -246,7 +251,7 @@ msgstr "Прокручування тексту"
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:394
+#: src/contents/ui/config/Compact.qml:409 src/contents/ui/config/Full.qml:407
 #, kde-format
 msgid "Speed:"
 msgstr "Швидкість:"
@@ -291,7 +296,7 @@ msgstr "Елементи керування відтворення"
 msgid "Space between controls"
 msgstr "Відступ між кнопками"
 
-#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:399
+#: src/contents/ui/config/Compact.qml:489 src/contents/ui/config/Full.qml:412
 #, kde-format
 msgid "Background"
 msgstr "Фон"
@@ -328,139 +333,154 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Очистити піктограму"
 
-#: src/contents/ui/config/Full.qml:48
+#: src/contents/ui/config/Full.qml:49
 #, fuzzy, kde-format
 msgid "Show album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:53
+#: src/contents/ui/config/Full.qml:54
 #, kde-format
 msgid "Show progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:63
+#: src/contents/ui/config/Full.qml:64
 #, kde-format
 msgid "Left"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:87
+#: src/contents/ui/config/Full.qml:88
 #, kde-format
 msgid "Right"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:109
+#: src/contents/ui/config/Full.qml:110
 #, fuzzy, kde-format
 msgid "Song text position:"
 msgstr "Позиція назви композиції:"
 
-#: src/contents/ui/config/Full.qml:110
+#: src/contents/ui/config/Full.qml:111
 #, kde-format
 msgid "Above progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:122
+#: src/contents/ui/config/Full.qml:123
 #, kde-format
 msgid "Under progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:135
+#: src/contents/ui/config/Full.qml:136
 #, fuzzy, kde-format
 msgid "Show volume control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:140
+#: src/contents/ui/config/Full.qml:141
 #, fuzzy, kde-format
 msgid "Show shuffle control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:145
+#: src/contents/ui/config/Full.qml:146
 #, fuzzy, kde-format
 msgid "Show playback controls"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:150
+#: src/contents/ui/config/Full.qml:151
 #, fuzzy, kde-format
 msgid "Show loop control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:154
+#: src/contents/ui/config/Full.qml:155
+#, kde-format
+msgid "Show synced lyrics"
+msgstr "Показувати синхронізовані тексти"
+
+#: src/contents/ui/config/Full.qml:161
+#, kde-format
+msgid ""
+"When enabled, the lyrics button appears in Full View. Opening lyrics sends "
+"the current track title, artist, album, and duration to LRCLIB."
+msgstr ""
+"Якщо увімкнено, у повному перегляді з'являється кнопка текстів. Відкриття "
+"текстів надсилає назву, виконавця, альбом і тривалість поточного треку до "
+"LRCLIB."
+
+#: src/contents/ui/config/Full.qml:167
 #, fuzzy, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Заповнити доступний простір панелі"
 
-#: src/contents/ui/config/Full.qml:160
+#: src/contents/ui/config/Full.qml:173
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:167
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:175
+#: src/contents/ui/config/Full.qml:188
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:183
+#: src/contents/ui/config/Full.qml:196
 #, kde-format
 msgid "Album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:187
+#: src/contents/ui/config/Full.qml:200
 #, kde-format
 msgid "Album placeholder:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:190 src/contents/ui/config/General.qml:101
+#: src/contents/ui/config/Full.qml:203 src/contents/ui/config/General.qml:101
 #, kde-format
 msgid "Choose…"
 msgstr "Вибрати…"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:211
 #, kde-format
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/contents/ui/config/Full.qml:219
+#: src/contents/ui/config/Full.qml:232
 #, fuzzy, kde-format
 msgid "Round album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:235
+#: src/contents/ui/config/Full.qml:248
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Налаштування опису композиції"
 
-#: src/contents/ui/config/Full.qml:408
+#: src/contents/ui/config/Full.qml:421
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Фон (лише для стільникового віджета)"
 
-#: src/contents/ui/config/Full.qml:410
+#: src/contents/ui/config/Full.qml:423
 #, kde-format
 msgid "Standard"
 msgstr "Стандартний"
 
-#: src/contents/ui/config/Full.qml:426
+#: src/contents/ui/config/Full.qml:439
 #, kde-format
 msgid "Transparent"
 msgstr "Прозорий"
 
-#: src/contents/ui/config/Full.qml:437
+#: src/contents/ui/config/Full.qml:450
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Прозорий (з тінями від вмісту)"
 
-#: src/contents/ui/config/Full.qml:454
+#: src/contents/ui/config/Full.qml:467
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Використовувати обкладинку як фон"
 
-#: src/contents/ui/config/Full.qml:456
+#: src/contents/ui/config/Full.qml:469
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Експериментальна функція)"


### PR DESCRIPTION
Hey, been using this widget for a long time and decided to add the one feature I was missing: lyrics.

This change adds an option to enable and show live syncing lyrics in full view. It can be enabled in the settings for Full View and once enabled, an additional show/hide lyrics button shows next to the playback buttons. Clicking the button switches to lyrics view and clicking again switches back to album art view.

See attached screenshots. I've updated the README as well but I'm not sure if it's okay to include screenshots with lyrics in README because of potential copyright issues so left them out for now.

The lyrics themselves come from LRCLIB, and the User Agent points to this widget and this repo as per their recommendation here https://lrclib.net/docs.

Tested with `QML_DISABLE_DISK_CACHE=1 plasmoidviewer -a src/`.

Disclaimer: this was AI assisted. The code was initially written by Opus 4.6 then reviewed and cleaned up by Codex 5.4. The changes look sane to me but please let me know if you have any comments.

<img width="1270" height="972" alt="Screenshot_20260411_131524" src="https://github.com/user-attachments/assets/d65f5c80-d1d1-42d9-b265-75f385ee6710" />
<img width="491" height="752" alt="Screenshot_20260411_131612" src="https://github.com/user-attachments/assets/323e622d-6566-42b9-b513-3f83edbeabca" />
<img width="469" height="734" alt="Screenshot_20260411_131730" src="https://github.com/user-attachments/assets/f5fe174b-594a-4540-a526-1f67d2f5d3f5" />
