### PR TITLE
fix: Hide widget when no media playing

### DIFF
--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -125,15 +125,6 @@ QtObject {
     readonly property real volume: ready ? mpris2Model.currentPlayer.volume : 0
     readonly property string identity: ready ? mpris2Model.currentPlayer.identity : ""
 
-    // True when the MPRIS source is a web browser.
-    // Browsers register themselves as MPRIS sources as soon as they launch,
-    // so `ready` alone cannot tell us whether a media tab is actually open.
-    readonly property bool isBrowser: {
-        const knownBrowsers = ["chromium", "chrome", "brave", "opera", "vivaldi", "edge"];
-        const id = identity.toLowerCase();
-        return knownBrowsers.some(b => id.includes(b));
-    }
-
     readonly property bool canGoNext: ready ? mpris2Model.currentPlayer.canGoNext : false
     readonly property bool canGoPrevious: ready ? mpris2Model.currentPlayer.canGoPrevious : false
     readonly property bool canPlay: ready ? mpris2Model.currentPlayer.canPlay : false

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -49,6 +49,15 @@ QtObject {
     readonly property real volume: ready ? mpris2Model.currentPlayer.volume : 0
     readonly property string identity: ready ? mpris2Model.currentPlayer.identity : ""
 
+    // True when the MPRIS source is a web browser.
+    // Browsers register themselves as MPRIS sources as soon as they launch,
+    // so `ready` alone cannot tell us whether a media tab is actually open.
+    readonly property bool isBrowser: {
+        const knownBrowsers = ["firefox", "chromium", "chrome", "brave", "opera", "vivaldi", "edge"];
+        const id = identity.toLowerCase();
+        return knownBrowsers.some(b => id.includes(b));
+    }
+
     readonly property bool canGoNext: ready ? mpris2Model.currentPlayer.canGoNext : false
     readonly property bool canGoPrevious: ready ? mpris2Model.currentPlayer.canGoPrevious : false
     readonly property bool canPlay: ready ? mpris2Model.currentPlayer.canPlay : false

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -125,6 +125,15 @@ QtObject {
     readonly property real volume: ready ? mpris2Model.currentPlayer.volume : 0
     readonly property string identity: ready ? mpris2Model.currentPlayer.identity : ""
 
+    // True when the MPRIS source is a web browser.
+    // Browsers register themselves as MPRIS sources as soon as they launch,
+    // so `ready` alone cannot tell us whether a media tab is actually open.
+    readonly property bool isBrowser: {
+        const knownBrowsers = ["firefox", "chromium", "chrome", "brave", "opera", "vivaldi", "edge"];
+        const id = identity.toLowerCase();
+        return knownBrowsers.some(b => id.includes(b));
+    }
+
     readonly property bool canGoNext: ready ? mpris2Model.currentPlayer.canGoNext : false
     readonly property bool canGoPrevious: ready ? mpris2Model.currentPlayer.canGoPrevious : false
     readonly property bool canPlay: ready ? mpris2Model.currentPlayer.canPlay : false

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -107,10 +107,15 @@ QtObject {
         if (!mpris2Model.currentPlayer) {
             return false;
         }
-        if (!sourceIdentities) {
-            return true;
+        if (sourceIdentities && !sourceIdentities.includes(mpris2Model.currentPlayer.identity)) {
+            return false;
         }
-        return sourceIdentities.includes(mpris2Model.currentPlayer.identity);
+        // Chromium-based browsers stay registered on MPRIS even after the media tab
+        // is closed, without clearing their metadata. Requiring actual metadata
+        // prevents the widget from staying visible in that case.
+        return !!(mpris2Model.currentPlayer.track
+               || mpris2Model.currentPlayer.artist
+               || mpris2Model.currentPlayer.album);
     }
 
     readonly property string artists: ready ? mpris2Model.currentPlayer.artist : ""

--- a/src/contents/ui/Player.qml
+++ b/src/contents/ui/Player.qml
@@ -129,7 +129,7 @@ QtObject {
     // Browsers register themselves as MPRIS sources as soon as they launch,
     // so `ready` alone cannot tell us whether a media tab is actually open.
     readonly property bool isBrowser: {
-        const knownBrowsers = ["firefox", "chromium", "chrome", "brave", "opera", "vivaldi", "edge"];
+        const knownBrowsers = ["chromium", "chrome", "brave", "opera", "vivaldi", "edge"];
         const id = identity.toLowerCase();
         return knownBrowsers.some(b => id.includes(b));
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,6 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -19,6 +18,23 @@ PlasmoidItem {
     readonly property bool hidePlayerControlBinds: plasmoid.configuration.hidePlayerControlBindsInHoverTooltip
 
     readonly property font baseFont: plasmoid.configuration.useCustomFont ? plasmoid.configuration.customFont : Kirigami.Theme.defaultFont
+
+    function updateStatus() {
+        Plasmoid.status = computeStatus()
+    }
+
+    // showWhenNoMedia: always visible (user override)
+    // native player: visible as soon as the app is open (player.ready)
+    // browser: visible only when a media tab is open (non-empty title)
+    function computeStatus() {
+        if (showWhenNoMedia) return PlasmaCore.Types.ActiveStatus;
+        if (!player.ready) return PlasmaCore.Types.HiddenStatus;
+        if (player.isBrowser && player.title === "") {
+            return PlasmaCore.Types.HiddenStatus;
+        }
+        return PlasmaCore.Types.ActiveStatus;
+    }
+
 
     toolTipTextFormat: Text.PlainText
     toolTipMainText: player.playbackStatus > Mpris.PlaybackStatus.Stopped ? player.title : i18n("No media playing")
@@ -33,9 +49,7 @@ PlasmoidItem {
         return text
     }
 
-    onShowWhenNoMediaChanged: {
-        Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-    }
+    onShowWhenNoMediaChanged: updateStatus()
 
     Player {
         id: player
@@ -44,15 +58,10 @@ PlasmoidItem {
                 return plasmoid.configuration.preferredPlayerIdentity
             }
         }
-        onReadyChanged: {
-            Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-            console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-        onPlaybackStatusChanged: {
-            Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-            console.debug(`Playback status changed: ${player.playbackStatus} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-
+        onReadyChanged: widget.updateStatus()
+        onPlaybackStatusChanged: widget.updateStatus()
+        onTitleChanged: widget.updateStatus()
+        onIsBrowserChanged: widget.updateStatus()
     }
 
     compactRepresentation: Compact {}

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,6 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -19,6 +18,23 @@ PlasmoidItem {
     readonly property bool hidePlayerControlBinds: plasmoid.configuration.hidePlayerControlBindsInHoverTooltip
 
     readonly property font baseFont: plasmoid.configuration.useCustomFont ? plasmoid.configuration.customFont : Kirigami.Theme.defaultFont
+
+    function updateStatus() {
+        Plasmoid.status = computeStatus()
+    }
+
+    // showWhenNoMedia: always visible (user override)
+    // native player: visible as soon as the app is open (player.ready)
+    // browser: visible only when a media tab is open (non-empty title)
+    function computeStatus() {
+        if (showWhenNoMedia) return PlasmaCore.Types.ActiveStatus;
+        if (!player.ready) return PlasmaCore.Types.HiddenStatus;
+        if (player.isBrowser && player.title === "") {
+            return PlasmaCore.Types.HiddenStatus;
+        }
+        return PlasmaCore.Types.ActiveStatus;
+    }
+
 
     toolTipTextFormat: Text.PlainText
     toolTipMainText: player.playbackStatus > Mpris.PlaybackStatus.Stopped ? player.title : i18n("No media playing")
@@ -33,9 +49,7 @@ PlasmoidItem {
         return text
     }
 
-    onShowWhenNoMediaChanged: {
-        Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-    }
+    onShowWhenNoMediaChanged: updateStatus()
 
     Player {
         id: player
@@ -46,15 +60,10 @@ PlasmoidItem {
             }
             return null
         }
-        onReadyChanged: {
-            Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-            console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-        onPlaybackStatusChanged: {
-            Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
-            console.debug(`Playback status changed: ${player.playbackStatus} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-
+        onReadyChanged: widget.updateStatus()
+        onPlaybackStatusChanged: widget.updateStatus()
+        onTitleChanged: widget.updateStatus()
+        onIsBrowserChanged: widget.updateStatus()
     }
 
     compactRepresentation: Compact {}

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,7 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+    Plasmoid.status: (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -34,7 +34,7 @@ PlasmoidItem {
     }
 
     onShowWhenNoMediaChanged: {
-        Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+        Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     }
 
     Player {
@@ -49,6 +49,10 @@ PlasmoidItem {
         onReadyChanged: {
             Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
             console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
+        onPlaybackStatusChanged: {
+            Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+            console.debug(`Playback status changed: ${player.playbackStatus} -> plasmoid status changed: ${Plasmoid.status}`)
         }
 
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,7 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+    Plasmoid.status: (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -34,7 +34,7 @@ PlasmoidItem {
     }
 
     onShowWhenNoMediaChanged: {
-        Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+        Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     }
 
     Player {
@@ -47,6 +47,10 @@ PlasmoidItem {
         onReadyChanged: {
             Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
             console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
+        onPlaybackStatusChanged: {
+            Plasmoid.status = (showWhenNoMedia || (player.ready && player.playbackStatus > Mpris.PlaybackStatus.Stopped)) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+            console.debug(`Playback status changed: ${player.playbackStatus} -> plasmoid status changed: ${Plasmoid.status}`)
         }
 
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,7 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: player.updateStatus()
+    Plasmoid.status: (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -33,15 +33,12 @@ PlasmoidItem {
         return text
     }
 
-    onShowWhenNoMediaChanged: player.updateStatus()
+    onShowWhenNoMediaChanged: {
+        Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
+    }
 
     Player {
         id: player
-
-        // Some browsers keep the MPRIS container active even after the player tab has been closed,
-        // which causes the player to be always "ready" due to the presence of the container.
-        // Checking for the presence of metadata is a simple way to work around this issue.
-        readonly property bool isMediaInfoSet: player.title || player.artists || player.album
 
         sourceIdentities: {
             if (!plasmoid.configuration.choosePlayerAutomatically) {
@@ -51,20 +48,8 @@ PlasmoidItem {
             return null
         }
         onReadyChanged: {
-            updateStatus();
+            Plasmoid.status = (showWhenNoMedia || player.ready) ? PlasmaCore.Types.ActiveStatus : PlasmaCore.Types.HiddenStatus
             console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-        onIsMediaInfoSetChanged: {
-            updateStatus();
-            console.debug(`Player media info changed: ${player.isMediaInfoSet} -> plasmoid status changed: ${Plasmoid.status}`)
-        }
-
-        function updateStatus() {
-            if (!showWhenNoMedia && !isMediaInfoSet) {
-                Plasmoid.status = PlasmaCore.Types.HiddenStatus;
-            } else {
-                Plasmoid.status = PlasmaCore.Types.ActiveStatus;
-            }
         }
 
     }

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,7 +10,7 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
-    Plasmoid.status: widget.updateStatus()
+    Plasmoid.status: player.updateStatus()
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor
@@ -19,23 +19,6 @@ PlasmoidItem {
     readonly property bool hidePlayerControlBinds: plasmoid.configuration.hidePlayerControlBindsInHoverTooltip
 
     readonly property font baseFont: plasmoid.configuration.useCustomFont ? plasmoid.configuration.customFont : Kirigami.Theme.defaultFont
-
-    function updateStatus() {
-        Plasmoid.status = computeStatus()
-    }
-
-    // showWhenNoMedia: always visible (user override)
-    // native player: visible as soon as the app is open (player.ready)
-    // browser: visible only when a media tab is open (non-empty title)
-    function computeStatus() {
-        if (showWhenNoMedia) return PlasmaCore.Types.ActiveStatus;
-        if (!player.ready) return PlasmaCore.Types.HiddenStatus;
-        if (player.isBrowser && player.title === "") {
-            return PlasmaCore.Types.HiddenStatus;
-        }
-        return PlasmaCore.Types.ActiveStatus;
-    }
-
 
     toolTipTextFormat: Text.PlainText
     toolTipMainText: player.playbackStatus > Mpris.PlaybackStatus.Stopped ? player.title : i18n("No media playing")
@@ -50,10 +33,16 @@ PlasmoidItem {
         return text
     }
 
-    onShowWhenNoMediaChanged: updateStatus()
+    onShowWhenNoMediaChanged: player.updateStatus()
 
     Player {
         id: player
+
+        // Some browsers keep the MPRIS container active even after the player tab has been closed,
+        // which causes the player to be always "ready" due to the presence of the container.
+        // Checking for the presence of metadata is a simple way to work around this issue.
+        readonly property bool isMediaInfoSet: player.title || player.artists || player.album
+
         sourceIdentities: {
             if (!plasmoid.configuration.choosePlayerAutomatically) {
                 const identities = plasmoid.configuration.preferredPlayerIdentity
@@ -61,10 +50,23 @@ PlasmoidItem {
             }
             return null
         }
-        onReadyChanged: widget.updateStatus()
-        onPlaybackStatusChanged: widget.updateStatus()
-        onTitleChanged: widget.updateStatus()
-        onIsBrowserChanged: widget.updateStatus()
+        onReadyChanged: {
+            updateStatus();
+            console.debug(`Player ready changed: ${player.ready} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
+        onIsMediaInfoSetChanged: {
+            updateStatus();
+            console.debug(`Player media info changed: ${player.isMediaInfoSet} -> plasmoid status changed: ${Plasmoid.status}`)
+        }
+
+        function updateStatus() {
+            if (!showWhenNoMedia && !isMediaInfoSet) {
+                Plasmoid.status = PlasmaCore.Types.HiddenStatus;
+            } else {
+                Plasmoid.status = PlasmaCore.Types.ActiveStatus;
+            }
+        }
+
     }
 
     compactRepresentation: Compact {}

--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -10,6 +10,7 @@ import org.kde.plasma.private.mpris as Mpris
 PlasmoidItem {
     id: widget
 
+    Plasmoid.status: widget.updateStatus()
     Plasmoid.backgroundHints: plasmoid.configuration.desktopWidgetBg
 
     readonly property int formFactor: Plasmoid.formFactor


### PR DESCRIPTION
Hi,

When media playback stops, the widget remains visible instead of hiding as expected.  
It should only remain visible while media is playing or paused, unless the user has enabled "Show widget when no media found" option.

A check was added against `player.playbackStatus` for initialization and option changes.  
The `Player` object was updated with a new handler, `onPlaybackStatusChanged`, which allows toggle the visibility of the widget.

This fixes #266 and it's duplicate #294.