### PR TITLE
Hide hover context menu

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -183,5 +183,8 @@
         <entry name="hidePlayerControlBindsInHoverTooltip" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="hideCanBeRaisedTooltip" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -135,7 +135,7 @@ Item {
                 id: raisePlayerTooltip
                 anchors.centerIn: parent
                 text: player.canRaise ? i18n("Bring player to the front") : i18n("This player can't be raised")
-                visible: coverMouseArea.containsMouse
+                visible: !plasmoid.configuration.hideCanBeRaisedTooltip && coverMouseArea.containsMouse
             }
 
             MouseArea {

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -34,6 +34,7 @@ KCM.SimpleKCM {
     property alias cfg_fullViewMaxWidth: fullViewMaxWidth.value
     property alias cfg_fullAlbumCoverRounded: fullAlbumCoverRounded.checked
     property alias cfg_fullAlbumCoverRadius: fullAlbumCoverRadius.value
+    property alias cfg_hideCanBeRaisedTooltip: hideCanBeRaisedTooltip.checked
 
     Kirigami.FormLayout {
         id: form
@@ -454,6 +455,16 @@ KCM.SimpleKCM {
             Kirigami.FormData.label: i18n("Use album cover as background")
             id: fullAlbumCoverAsBackground
             text: i18n("(Experimental feature)")
+        }
+        
+        Kirigami.Separator {
+            Kirigami.FormData.isSection: true
+            Kirigami.FormData.label: i18n("Hover tooltip")
+        }
+        
+        CheckBox{
+            id: hideCanBeRaisedTooltip
+            Kirigami.FormData.label: i18n("Hide album art tooltip")
         }
     }
 


### PR DESCRIPTION
Added a small option to hide the "Bring player to the front" or "This player can't be raised" tooltip that shows on the album cover when hovering in the full view. It was getting in the way when zooming in to the album art to see the details.