### PR TITLE
feat: Add player selector for switching between MPRIS players

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -186,5 +186,8 @@
         <entry name="hideCanBeRaisedTooltip" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="showPlayerSelector" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 </kcfg>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -157,12 +157,6 @@ Item {
                         text: isMultiplexer ? i18nc("@action:button", "Choose player automatically") : identity
 
                         Accessible.onPressAction: clicked()
-                        /*KeyNavigation.down: seekSlider.visible ? seekSlider : seekSlider.KeyNavigation.down
-                        KeyNavigation.backtab: expandedRepresentation.KeyNavigation.backtab || repeatButton
-                        KeyNavigation.up: expandedRepresentation.KeyNavigation.backtab || null
-                        Keys.onLeftPressed: event => playerSelector.handleArrows(event)
-                        Keys.onRightPressed: event => playerSelector.handleArrows(event)*/
-
                         onClicked: {
                             player.mpris2Model.currentIndex = index;
                         }

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -43,9 +43,6 @@ Item {
     Layout.minimumHeight: column.implicitHeight
     Layout.maximumHeight: column.implicitHeight
 
-    // Multi player selector visibility check
-    readonly property bool showPlayerSelector: playerList.count > 2
-
     // Store the original theme colors (root keeps default Kirigami.Theme.inherit: true)
     readonly property color _originalTextColor: Kirigami.Theme.textColor
     readonly property color _originalHighlightColor: Kirigami.Theme.highlightColor
@@ -127,7 +124,9 @@ Item {
         Rectangle {
             id: headerbar
             Layout.fillWidth: true
-            visible: showPlayerSelector
+            visible: plasmoid.configuration.showPlayerSelector
+                    && playerList.count > 2
+                    && player.sourceIdentities == null
 
             color: albumCoverBackground
                 ? "transparent"
@@ -158,6 +157,11 @@ Item {
                         text: isMultiplexer ? i18nc("@action:button", "Choose player automatically") : identity
 
                         Accessible.onPressAction: clicked()
+                        /*KeyNavigation.down: seekSlider.visible ? seekSlider : seekSlider.KeyNavigation.down
+                        KeyNavigation.backtab: expandedRepresentation.KeyNavigation.backtab || repeatButton
+                        KeyNavigation.up: expandedRepresentation.KeyNavigation.backtab || null
+                        Keys.onLeftPressed: event => playerSelector.handleArrows(event)
+                        Keys.onRightPressed: event => playerSelector.handleArrows(event)*/
 
                         onClicked: {
                             player.mpris2Model.currentIndex = index;

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -118,6 +118,53 @@ Item {
         Kirigami.Theme.inherit: false
         Kirigami.Theme.textColor: albumCoverBackground ? imageColors.fgColor : root._originalTextColor
         Kirigami.Theme.highlightColor: albumCoverBackground ? imageColors.hlColor : root._originalHighlightColor
+        
+        // Media Player Selector
+        Rectangle {
+            id: headerbar
+            Layout.fillWidth: true
+            visible: playerList.count > 2
+
+            color: albumCoverBackground
+                ? Qt.rgba(0, 0, 0, 0.25)
+                : Kirigami.Theme.backgroundColor
+
+            implicitHeight: Kirigami.Units.gridUnit * 2
+
+            PlasmaComponents3.TabBar {
+                id: playerSelector
+                objectName: "playerSelector"               
+                anchors.fill: parent
+                implicitHeight: contentHeight
+                currentIndex: playerSelector.count, player.mpris2Model.currentIndex
+                
+                Repeater {
+                    id: playerList
+                    model: player.mpris2Model
+                    delegate: PlasmaComponents3.TabButton {
+                        required property string iconName
+                        required property bool isMultiplexer
+                        required property string identity
+                        required property int index
+                        anchors.top: parent?.top
+                        anchors.bottom: parent?.bottom
+                        display: PlasmaComponents3.AbstractButton.IconOnly
+                        icon.name: iconName
+                        icon.height: Kirigami.Units.iconSizes.small 
+                        text: isMultiplexer ? i18nc("@action:button", "Choose player automatically") : identity
+                        Accessible.onPressAction: clicked()
+
+                        onClicked: {
+                            player.mpris2Model.currentIndex = index;
+                        }
+
+                        PlasmaComponents3.ToolTip.text: text
+                        PlasmaComponents3.ToolTip.delay: Kirigami.Units.toolTipDelay
+                        PlasmaComponents3.ToolTip.visible: hovered || (activeFocus && (focusReason === Qt.TabFocusReason || focusReason === Qt.BacktabFocusReason))
+                    }    
+                }    
+            }
+        }
 
         Rectangle {
             id: thumbnailContainer

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -43,6 +43,9 @@ Item {
     Layout.minimumHeight: column.implicitHeight
     Layout.maximumHeight: column.implicitHeight
 
+    // Multi player selector visibility check
+    readonly property bool showPlayerSelector: playerList.count > 2
+
     // Store the original theme colors (root keeps default Kirigami.Theme.inherit: true)
     readonly property color _originalTextColor: Kirigami.Theme.textColor
     readonly property color _originalHighlightColor: Kirigami.Theme.highlightColor
@@ -99,8 +102,9 @@ Item {
             id: mask
             anchors.fill: parent
             gradient: Gradient {
-                GradientStop { position: 0; color: "transparent" }
-                GradientStop { position: 0.4; color: "transparent" }
+                GradientStop { position: 0; color: showPlayerSelector ? imageColors.bgColor : "transparent" }   // Adjust top gradient when the player selector is visible
+                GradientStop { position: 0.11; color: "transparent" }
+                GradientStop { position: showPlayerSelector ? 0.5 : 0.4; color: "transparent" }
                 GradientStop { position: 0.7; color: imageColors.bgColor }
                 GradientStop { position: 1; color: imageColors.bgColor }
             }
@@ -123,10 +127,10 @@ Item {
         Rectangle {
             id: headerbar
             Layout.fillWidth: true
-            visible: playerList.count > 2
+            visible: showPlayerSelector
 
             color: albumCoverBackground
-                ? Qt.rgba(0, 0, 0, 0.25)
+                ? "transparent"
                 : Kirigami.Theme.backgroundColor
 
             implicitHeight: Kirigami.Units.gridUnit * 2
@@ -136,7 +140,7 @@ Item {
                 objectName: "playerSelector"               
                 anchors.fill: parent
                 implicitHeight: contentHeight
-                currentIndex: playerSelector.count, player.mpris2Model.currentIndex
+                currentIndex: player.mpris2Model.currentIndex
                 
                 Repeater {
                     id: playerList
@@ -150,8 +154,9 @@ Item {
                         anchors.bottom: parent?.bottom
                         display: PlasmaComponents3.AbstractButton.IconOnly
                         icon.name: iconName
-                        icon.height: Kirigami.Units.iconSizes.small 
+                        icon.height: Kirigami.Units.iconSizes.small
                         text: isMultiplexer ? i18nc("@action:button", "Choose player automatically") : identity
+
                         Accessible.onPressAction: clicked()
 
                         onClicked: {

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -32,6 +32,7 @@ KCM.SimpleKCM {
     property alias cfg_fullViewSongTextPosition: fullViewSongTextPosition.value
     property alias cfg_fullViewMinWidth: fullViewMinWidth.value
     property alias cfg_fullViewMaxWidth: fullViewMaxWidth.value
+    property alias cfg_showPlayerSelector: showPlayerSelector.checked
     property alias cfg_fullAlbumCoverRounded: fullAlbumCoverRounded.checked
     property alias cfg_fullAlbumCoverRadius: fullAlbumCoverRadius.value
     property alias cfg_hideCanBeRaisedTooltip: hideCanBeRaisedTooltip.checked
@@ -177,6 +178,18 @@ KCM.SimpleKCM {
             from: fullViewMinWidth.value
             to: 2000
             stepSize: 10
+        }
+
+        RowLayout{
+            Kirigami.FormData.label: i18n("Show media player selector")
+            CheckBox {
+                id: showPlayerSelector
+            }
+            Kirigami.ContextualHelpButton {
+                toolTipText: i18n(
+                    "Disabled when a preferred player is selected under General > Playback Source. Only works when 'Choose automatically' is selected."
+                )
+            }
         }
 
         Kirigami.Separator {
@@ -380,7 +393,7 @@ KCM.SimpleKCM {
                 )
             }
         }
-        
+
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Kirigami.FormData.label: i18n("Text scrolling")
@@ -456,12 +469,12 @@ KCM.SimpleKCM {
             id: fullAlbumCoverAsBackground
             text: i18n("(Experimental feature)")
         }
-        
+
         Kirigami.Separator {
             Kirigami.FormData.isSection: true
             Kirigami.FormData.label: i18n("Hover tooltip")
         }
-        
+
         CheckBox{
             id: hideCanBeRaisedTooltip
             Kirigami.FormData.label: i18n("Hide album art tooltip")


### PR DESCRIPTION
This PR adds a player selector to the full view. (#65)

The selector allows users to switch between multiple MPRIS media players directly from PlasMusic without opening the default KDE media player widget.

#310 Proposed for a dropdown menu but I think this would be a good base to work forward to it.

Features:
- Uses the existing MPRIS model
- Displays available media players as tabs
- Shows tooltips for player identities
- Adapts to album cover background mode

Future improvements:
 - Additional visual polish for album-background mode (Implemented)
- Keyboard navigation integration

<img width="430" height="540" alt="image" src="https://github.com/user-attachments/assets/74b23c9e-8268-4ec4-a41f-9fcd8ca16d3c" />
<img width="433" height="524" alt="image" src="https://github.com/user-attachments/assets/ff00068b-0565-4ede-b4d9-b43f288b03e5" />


Sorry for my wierd commit names and higher numbers of commits. This was my first PR and I recently got to know the convention of commits.