### PR TITLE
fix: Remove conflicting `expanded` property from widget

### DIFF
--- a/src/contents/ui/main.qml
+++ b/src/contents/ui/main.qml
@@ -15,7 +15,6 @@ PlasmoidItem {
 
     readonly property int formFactor: Plasmoid.formFactor
     readonly property int location: Plasmoid.location
-    property bool expanded: Plasmoid.expanded == true
     readonly property bool showWhenNoMedia: plasmoid.configuration.showWhenNoMedia
     readonly property bool hidePlayerControlBinds: plasmoid.configuration.hidePlayerControlBindsInHoverTooltip
 


### PR DESCRIPTION
The `PlasmoidItem` object has a native `expanded` property. Defining a custom `expanded` property on the widget causes a direct collision with this native property, leading to undefined behavior and runtime issues.

Closes #328 