### PR TITLE
fix(ci): asset upload with immutable releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -52,3 +52,10 @@ jobs:
           TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
         run: |
           gh release upload "$TAG_NAME" "./plasmusic-toolbar-${TAG_NAME}.plasmoid"
+
+      - name: Publish release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          gh release edit "$TAG_NAME" --draft=false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
         ".": {
             "changelog-path": "CHANGELOG.md",
             "release-type": "simple",
+            "draft": true,
             "extra-files": [
                 {
                   "type": "json",


### PR DESCRIPTION
With immutable releases enabled on GitHub, assets can no longer be modified once a release is published. release-please was publishing the release immediately, so the build-release job's attempt to upload the .plasmoid package afterwards failed.

This change makes release-please create the release as a draft, uploads the asset while it's still a draft, and then publishes it as the final step.