### PR TITLE
chore: correct changelog to remove erroneous commit reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 ### Bug Fixes
 
 * **ci:** asset upload with immutable releases ([#334](https://github.com/ccatterina/plasmusic-toolbar/issues/334)) ([fae865a](https://github.com/ccatterina/plasmusic-toolbar/commit/fae865a1330c7f973dda4c3e3b75f6c3f5f6b4bc))
-* **ci:** checkout release commit by sha to support draft releases ([c422314](https://github.com/ccatterina/plasmusic-toolbar/commit/c42231411b728b7aefbc98afa4ffcdf4dc3e117a))
 
 **Note:** release 4.3.0 did not include the `.plasmoid` package due to a CI pipeline issue (immutable releases blocked the asset upload after publishing). This release fixes the issue and includes the correct package.
 


### PR DESCRIPTION
Due to a release pipeline error, the initial release job broke, requiring several attempts to fix it. During this process, commit c422314 was mistakenly included in the changelog, even though it was not actually part of the v4.3.1 tag.

This commit removes the incorrect entry to keep the changelog consistent with the actual contents of the v4.3.1 release.