### PR TITLE
Allow resizing the full view popup height

### DIFF
--- a/src/contents/config/main.xml
+++ b/src/contents/config/main.xml
@@ -162,6 +162,12 @@
         <entry name="fullViewMaxWidth" type="Int">
             <default>300</default>
         </entry>
+        <entry name="fullViewMinHeight" type="Int">
+            <default>100</default>
+        </entry>
+        <entry name="fullViewMaxHeight" type="Int">
+            <default>600</default>
+        </entry>
 		<entry name="fullAlbumCoverRounded" type="Bool">
 			<default>true</default>
 		</entry>

--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -34,6 +34,8 @@ Item {
     // The Full View max and min width is driven by config values. The window can be resized within these bounds; thumbnail and text adapt.
     readonly property int configMinWidth: plasmoid.configuration.fullViewMinWidth
     readonly property int maximumWidth: plasmoid.configuration.fullViewMaxWidth
+    readonly property int configMinHeight: plasmoid.configuration.fullViewMinHeight
+    readonly property int maximumHeight: plasmoid.configuration.fullViewMaxHeight
     property bool fullAlbumCoverRounded: plasmoid.configuration.fullAlbumCoverRounded
     property int albumCoverRadius: plasmoid.configuration.fullAlbumCoverRadius
 
@@ -41,12 +43,20 @@ Item {
     readonly property int contentMinWidth: row.visible ? row.implicitWidth + 40 : 0
     readonly property int effectiveMinWidth: Math.min(Math.max(configMinWidth, contentMinWidth), maximumWidth)
 
+    // Stable (width-independent) preferred thumbnail height, referenced to the min width, so that
+    // resizing the popup width doesn't drag the height along with it (the "aspect ratio lock").
+    readonly property real naturalThumbHeight: thumbnailVisible && thumbnailContainer.imageRatio > 0
+        ? effectiveMinWidth / thumbnailContainer.imageRatio
+        : 0
+    // Height floor that keeps the fixed content (everything except the flexible thumbnail) from clipping.
+    readonly property real fixedContentHeight: Math.max(0, column.implicitHeight - naturalThumbHeight)
+
     Layout.minimumWidth: effectiveMinWidth
     Layout.maximumWidth: maximumWidth
     Layout.preferredWidth: effectiveMinWidth
     Layout.preferredHeight: column.implicitHeight
-    Layout.minimumHeight: column.implicitHeight
-    Layout.maximumHeight: column.implicitHeight
+    Layout.minimumHeight: Math.max(configMinHeight, fixedContentHeight)
+    Layout.maximumHeight: maximumHeight
 
     // Store the original theme colors (root keeps default Kirigami.Theme.inherit: true)
     readonly property color _originalTextColor: Kirigami.Theme.textColor
@@ -178,12 +188,16 @@ Item {
             id: thumbnailContainer
             visible: thumbnailVisible
             Layout.fillWidth: true
+            Layout.fillHeight: true
             Layout.margins: 10
+            Layout.minimumHeight: 0
             // Use the actual image aspect ratio, fallback to square if not loaded yet
             readonly property real imageRatio: albumArtNormal.implicitWidth > 0 && albumArtNormal.implicitHeight > 0
                 ? albumArtNormal.implicitWidth / albumArtNormal.implicitHeight
                 : 1.0
-            Layout.preferredHeight: thumbnailVisible ? width / imageRatio : 0
+            // Preferred height is stable (not tied to the current width) so the popup height
+            // stays independent of the width. Extra vertical space is absorbed here.
+            Layout.preferredHeight: root.naturalThumbHeight
             color: 'transparent'
 
             PlasmaComponents3.ToolTip {

--- a/src/contents/ui/config/Full.qml
+++ b/src/contents/ui/config/Full.qml
@@ -33,6 +33,8 @@ KCM.SimpleKCM {
     property alias cfg_fullViewSongTextPosition: fullViewSongTextPosition.value
     property alias cfg_fullViewMinWidth: fullViewMinWidth.value
     property alias cfg_fullViewMaxWidth: fullViewMaxWidth.value
+    property alias cfg_fullViewMinHeight: fullViewMinHeight.value
+    property alias cfg_fullViewMaxHeight: fullViewMaxHeight.value
     property alias cfg_showPlayerSelector: showPlayerSelector.checked
     property alias cfg_fullAlbumCoverRounded: fullAlbumCoverRounded.checked
     property alias cfg_fullAlbumCoverRadius: fullAlbumCoverRadius.value
@@ -177,6 +179,22 @@ KCM.SimpleKCM {
             id: fullViewMaxWidth
             Kirigami.FormData.label: i18n("Maximum resizable width:")
             from: fullViewMinWidth.value
+            to: 2000
+            stepSize: 10
+        }
+
+        SpinBox {
+            id: fullViewMinHeight
+            Kirigami.FormData.label: i18n("Minimum resizable height:")
+            from: 100
+            to: fullViewMaxHeight.value
+            stepSize: 10
+        }
+
+        SpinBox {
+            id: fullViewMaxHeight
+            Kirigami.FormData.label: i18n("Maximum resizable height:")
+            from: fullViewMinHeight.value
             to: 2000
             stepSize: 10
         }

--- a/src/translate/es_ES.po
+++ b/src/translate/es_ES.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-05-03 14:58+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,23 +32,23 @@ msgstr "Vista de panel"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Traer reproductor al frente"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Este reproductor no puede ser mostrado"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Disposición"
@@ -72,7 +72,7 @@ msgstr ""
 "debajo); El texto de la canción puede ser posicionado basado en las "
 "preferencias del usuario."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Alineación del texto de la canción:"
@@ -82,7 +82,7 @@ msgstr "Alineación del texto de la canción:"
 msgid "Left (Top for vertical panel)"
 msgstr "Izquierda (Encima para el panel vertical)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Centro"
@@ -97,7 +97,7 @@ msgstr "Derecha (Debajo para el panel vertical)"
 msgid "Show icon:"
 msgstr "Enseñar el icono:"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Enseñar el texto de la canción"
@@ -143,7 +143,7 @@ msgstr "Utilizar la portada del álbum como icono"
 msgid "Fallback to icon if cover is not available"
 msgstr "Utilizar icono de repuesto si la portada no está disponible"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Radio de la portada del álbum:"
@@ -153,51 +153,51 @@ msgstr "Radio de la portada del álbum:"
 msgid "Song text customization"
 msgstr "Personalización del texto de la canción"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Posición del título de la canción:"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Escondido"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "Primera línea"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Segunda línea"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Posición del artista:"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Posición del título del álbum:"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Esconder el nombre del álbum para sencillos:"
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -246,7 +246,7 @@ msgstr "Desvanecer"
 msgid "None"
 msgstr "Ninguno"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Desplazamiento del texto"
@@ -256,7 +256,7 @@ msgstr "Desplazamiento del texto"
 msgid "Enabled"
 msgstr "Activado"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Velocidad:"
@@ -301,7 +301,7 @@ msgstr "Personalización de los controles de reproducción"
 msgid "Space between controls"
 msgstr "Espacio entre controles"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Fondo"
@@ -328,7 +328,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Radio del fondo:"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr "Panel emergente"
@@ -350,67 +350,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Restablecer icono"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Enseñar portada del álbum"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "Enseñar barra de progeso"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Izquierda"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Derecha"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Posición del texto de la canción:"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "Encima de la barra de progreso"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "Debajo de la barra de progreso"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Enseñar controles de volumen"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Enseñar controles de modo aleatorio"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Enseñar controles de reproducción"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Enseñar control de bucle"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Rellenar el espacio disponible con los controles de reproducción"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -419,89 +419,99 @@ msgstr ""
 "Cuando esté activado, los controles de reproducción se expanden por todo el "
 "ancho del widget. Cuando esté desactivado, se agrupan en el centro."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Anchura redimensionable mínima:"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Anchura redimensionable máxima:"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Portada del álbum"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Sustituto del álbum:"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Elige..."
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Restablecer"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "Portada del álbum redondeada"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personalización del texto de la canción"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Fondo (sólamente widget de escritorio):"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Estándar"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Transparente"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Transparente (Ensombrecer contenido)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Utilizar portada del álbum como fondo"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Función experimental)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/fr.po
+++ b/src/translate/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-02-23 00:22+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,23 +32,23 @@ msgstr "Vue panneau"
 msgid "Full View"
 msgstr "Vue complète"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Mettre le lecteur au premier plan"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Ce lecteur ne peut pas être mis au premier plan"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Disposition"
@@ -71,7 +71,7 @@ msgstr ""
 "haut) et les contrôles de lecture sont alignés à droite (ou en bas) ; le "
 "texte de la chanson peut être positionné selon les préférences."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Alignement du texte :"
@@ -81,7 +81,7 @@ msgstr "Alignement du texte :"
 msgid "Left (Top for vertical panel)"
 msgstr "Gauche (Haut pour panneau vertical)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Centre"
@@ -96,7 +96,7 @@ msgstr "Droite (Bas pour panneau vertical)"
 msgid "Show icon:"
 msgstr "Afficher l'icône :"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Afficher le texte de la chanson"
@@ -142,7 +142,7 @@ msgstr "Utiliser la pochette comme icône"
 msgid "Fallback to icon if cover is not available"
 msgstr "Revenir à l'icône si la pochette n'est pas disponible"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrondi de la pochette :"
@@ -152,51 +152,51 @@ msgstr "Arrondi de la pochette :"
 msgid "Song text customization"
 msgstr "Personnalisation du texte du titre"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Position du titre :"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Caché"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "Première ligne"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Deuxième ligne"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Position de l'artiste :"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Position du titre d'album :"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -244,7 +244,7 @@ msgstr "Fondu"
 msgid "None"
 msgstr "Aucun"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Défilement du texte"
@@ -254,7 +254,7 @@ msgstr "Défilement du texte"
 msgid "Enabled"
 msgstr "Activé"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Vitesse :"
@@ -299,7 +299,7 @@ msgstr "Personnalisation des contrôles de lecture"
 msgid "Space between controls"
 msgstr "Espace entre les contrôles"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Fond"
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Arrondi du fond :"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr ""
@@ -348,67 +348,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Effacer l'icône"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Afficher la pochette"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "Afficher la barre de progression"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Gauche"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Droite"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Position du texte :"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "Au-dessus de la barre de progression"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "Sous la barre de progression"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Afficher le contrôle de volume"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Afficher le contrôle de lecture aléatoire"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Afficher les contrôles de lecture"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Afficher le contrôle de répétition"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Les contrôles de lecture remplissent l'espace disponible"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -417,89 +417,99 @@ msgstr ""
 "Lorsqu'activé, les contrôles de lecture sont répartis sur toute la largeur "
 "du widget. Lorsque désactivé, ils sont regroupés au centre."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Largeur minimale redimensionnable :"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Largeur maximale redimensionnable :"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Pochette d'album"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Image de remplacement :"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Choisir…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Effacer"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, fuzzy, kde-format
 msgid "Round album cover"
 msgstr "Pochette d'album arrondie"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personnalisation du texte"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Fond (widget bureau uniquement) :"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Standard"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Transparent"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Transparent (contenu ombré)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Utiliser la pochette comme fond"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Fonctionnalité expérimentale)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/it.po
+++ b/src/translate/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,23 +32,23 @@ msgstr "Vista pannello"
 msgid "Full View"
 msgstr "Vista completa"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Porta il player in primo piano"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Questo player non può essere portato in primo piano"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Disposizione"
@@ -72,7 +72,7 @@ msgstr ""
 "il testo della canzone può essere posizionato in base alle preferenze "
 "dell'utente."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Allineamento brano:"
@@ -82,7 +82,7 @@ msgstr "Allineamento brano:"
 msgid "Left (Top for vertical panel)"
 msgstr "Sinistra (Alto per pannello verticale)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Centro"
@@ -97,7 +97,7 @@ msgstr "Destra (Basso per pannello verticale)"
 msgid "Show icon:"
 msgstr "Mostra icona:"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Mostra brano"
@@ -143,7 +143,7 @@ msgstr "Usa copertina album come icona"
 msgid "Fallback to icon if cover is not available"
 msgstr "Usa icona se la copertina non è disponibile"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Arrotondamento bordo copertina album:"
@@ -153,51 +153,51 @@ msgstr "Arrotondamento bordo copertina album:"
 msgid "Song text customization"
 msgstr "Personalizzazione testo brano"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Posizionamento titolo:"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Nascosto"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "Prima riga"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Seconda riga"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Posizione artista/i:"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Posizione titolo album:"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Nascondi nome dell'album per i singoli:"
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -247,7 +247,7 @@ msgstr "Dissolvenza"
 msgid "None"
 msgstr "Nessuno"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Scorrimento testo"
@@ -257,7 +257,7 @@ msgstr "Scorrimento testo"
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Velocità:"
@@ -302,7 +302,7 @@ msgstr "Personalizzazione comandi di riproduzione"
 msgid "Space between controls"
 msgstr "Spazio tra i comandi"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Sfondo"
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Arrotondamento bordi sfondo:"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr "Suggerimenti a comparsa"
@@ -351,67 +351,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Resetta icona"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Mostra copertina album"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "Mostra barra progresso traccia"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Sinistra"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Destra"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Posizionamento titolo:"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "Sopra la barra di progresso traccia"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "Sotto la barra di progresso traccia"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Mostra comandi volume"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Mostra comando riproduzione casuale"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Mostra comandi di riproduzione"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Mostra comando riproduzione continua"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Riempi lo spazio disponibile con i comandi di riproduzione"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -420,89 +420,99 @@ msgstr ""
 "Quando abilitato, i comandi sono distribuiti sull'intera larghezza del "
 "widget. Quando disattivata, sono raggruppati al centro."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Larghezza minima:"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Larghezza massima:"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Copertina album"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Immagine placeholder per album:"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Scegli…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Resetta immagine"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "Arrotondamento immagine album"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personalizzazione testo canzone"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Sfondo (solo per widget desktop):"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Standard"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Trasparente"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Trasparente (Ombra)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Usa copertina album come sfondo"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "Funzionalità sperimentale"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/nl.po
+++ b/src/translate/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-03-15 10:48+0100\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: none\n"
@@ -33,23 +33,23 @@ msgstr "Paneelweergave"
 msgid "Full View"
 msgstr "Volledige weergave"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Speler naar voorgrond halen"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Deze speler kan niet naar de voorgrond worden gehaald"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Indeling"
@@ -72,7 +72,7 @@ msgstr ""
 "bovenaan uitgelijnd, en de afspeelbediening rechts of onderaan. De tekst kan "
 "op een locatie naar keuze worden getoond."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Tekst uitlijnen:"
@@ -82,7 +82,7 @@ msgstr "Tekst uitlijnen:"
 msgid "Left (Top for vertical panel)"
 msgstr "Links/Bovenaan"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Midden"
@@ -97,7 +97,7 @@ msgstr "Rechts/Onderaan"
 msgid "Show icon:"
 msgstr "Pictogram tonen:"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Titel van nummer tonen"
@@ -145,7 +145,7 @@ msgstr ""
 "Indien er geen hoes beschikbaar is, zal het standaardpictogram worden "
 "gebruikt"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albumhoesafmetingen:"
@@ -155,51 +155,51 @@ msgstr "Albumhoesafmetingen:"
 msgid "Song text customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Tekstlocatie:"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Verborgen"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "Eerste regel"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Tweede regel"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Artiestlocatie:"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Albumtitellocatie:"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Albumnaam verbergen indien gelijk aan single:"
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -247,7 +247,7 @@ msgstr "Vervaging"
 msgid "None"
 msgstr "Geen"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Tekst laten verschuiven"
@@ -257,7 +257,7 @@ msgstr "Tekst laten verschuiven"
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Snelheid:"
@@ -302,7 +302,7 @@ msgstr "Afspeelbediening aanpassen"
 msgid "Space between controls"
 msgstr "Ruimte tussen bedieningsknoppen"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Achtergrond"
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Achtergrondradius:"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr ""
@@ -351,67 +351,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Pictogram wissen"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Albumhoes tonen"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "Voortgangsbalk tonen"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Links"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Rechts"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Songtekstlocatie:"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "Boven voortgangsbalk"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "Onder voortgangsbalk"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Volumeregeling tonen"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Knoppen voor willekeurig afspelen tonen"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Afspeelbediening tonen"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Knoppen voor herhalen tonen"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Alle beschikbare paneelruimte gebruiken voor afspeelbediening"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -420,89 +420,99 @@ msgstr ""
 "Schakel in om de afspeelbediening over de gehele breedte van de widget te "
 "tonen. Schakel uit om in het midden te groeperen."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Minimale aanpasbare breedte:"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Maximale aanpasbare breedte:"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Albumhoes"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Plaatshouder van albumhoes:"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Kiezen…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Wissen"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "Albumhoezen voorzien van afgeronde hoeken"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Tekst aanpassen"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Achtergrond (alleen bureaubladwidget):"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Standaard"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Doorzichtig"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Doorzichtig, met schaduw"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Albumhoes gebruiken als achtergrond"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Experimentele functionaliteit)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/pt_BR.po
+++ b/src/translate/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-05-03 04:35-0300\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -31,23 +31,23 @@ msgstr "Visão no painel"
 msgid "Full View"
 msgstr "Visão completa"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Trazer o reprodutor para a frente"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Este reprodutor não pode ser exibido"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Formato"
@@ -70,7 +70,7 @@ msgstr ""
 "controles de reprodução são alinhados à direita (ou inferior);  o texto da "
 "música pode ser posicionado de acordo com a preferência do usuário."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Alinhamento do texto"
@@ -80,7 +80,7 @@ msgstr "Alinhamento do texto"
 msgid "Left (Top for vertical panel)"
 msgstr "Esquerda (Topo para painel vertical)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Centro"
@@ -95,7 +95,7 @@ msgstr "Direita (Inferior para painel vertical)"
 msgid "Show icon:"
 msgstr "Mostrar o ícone"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Mostrar texto da música"
@@ -141,7 +141,7 @@ msgstr "Usar a capa do álbum como ícone"
 msgid "Fallback to icon if cover is not available"
 msgstr "Caso a capa não esteja disponível, utilize o ícone como alternativa."
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Borda da capa do álbum"
@@ -151,51 +151,51 @@ msgstr "Borda da capa do álbum"
 msgid "Song text customization"
 msgstr "Personalização do texto da música"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Posição do título da música"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "primeira linha"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Segunda linha"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Posição do artista"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Posição do título do álbum"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Ocultar nome do álbum para singles"
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -244,7 +244,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Texto rolando"
@@ -254,7 +254,7 @@ msgstr "Texto rolando"
 msgid "Enabled"
 msgstr "Ativado"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Velocidade"
@@ -299,7 +299,7 @@ msgstr "Personalização dos controles de reprodução"
 msgid "Space between controls"
 msgstr "Espaço entre os controles"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Fundo"
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Borda do fundo"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr "Dica de ferramenta ao passar o cursor"
@@ -348,67 +348,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Limpar ícone"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Mostrar capa do álbum"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "Mostrar barra de progresso"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Esquerda"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Direita"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Posição do texto da música"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "Acima da barra de progresso"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "Abaixo da barra de progresso"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Mostrar controle de volume"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Mostra controle de reprodução aleatória"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Mostrar controles de reprodução"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Mostrar controle de repetição"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Prencher espaço disponível com os controles de reprodução"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -417,89 +417,99 @@ msgstr ""
 "Quando ativado, os controles de reprodução são distribuidos ao longo de toda "
 "a largura do widget. Quando desativado, eles são agrupados juntos no centro."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "largura mínima modificável"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Largura máxima modificável"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Capa do álbum"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Espaço reservado para capa do álbum"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Escolher"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Limpar"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "Capa do álbum aredondada"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Personalização do texto da música"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Fundo (apenas widget da área de trabalho):"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Padrão"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Transparente"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Transparente (com sombra)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Usar a capa do álbum como fundo"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Função experimental)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/template.pot
+++ b/src/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,23 +32,23 @@ msgstr ""
 msgid "Full View"
 msgstr ""
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr ""
@@ -67,7 +67,7 @@ msgid ""
 "positioned based on user preference."
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr ""
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Left (Top for vertical panel)"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr ""
@@ -92,7 +92,7 @@ msgstr ""
 msgid "Show icon:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr ""
@@ -138,7 +138,7 @@ msgstr ""
 msgid "Fallback to icon if cover is not available"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr ""
@@ -148,51 +148,51 @@ msgstr ""
 msgid "Song text customization"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr ""
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -238,7 +238,7 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr ""
@@ -248,7 +248,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr ""
@@ -293,7 +293,7 @@ msgstr ""
 msgid "Space between controls"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr ""
@@ -340,156 +340,166 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/tr.po
+++ b/src/translate/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-03-08 00:00+0300\n"
 "Last-Translator: A coffee lover\n"
 "Language-Team: none\n"
@@ -32,23 +32,23 @@ msgstr "Panel Görünümü"
 msgid "Full View"
 msgstr "Tam Görünüm"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Oynatıcıyı öne getir"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Bu oynatıcı öne getirilemez"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Yerleşim"
@@ -71,7 +71,7 @@ msgstr ""
 "kontrolleri sağa (veya alta) hizalanır; şarkı metni kullanıcı tercihine göre "
 "konumlandırılabilir."
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Şarkı metni hizalaması:"
@@ -81,7 +81,7 @@ msgstr "Şarkı metni hizalaması:"
 msgid "Left (Top for vertical panel)"
 msgstr "Sol (Dikey panel için üst)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "Orta"
@@ -96,7 +96,7 @@ msgstr "Sağ (Dikey panel için alt)"
 msgid "Show icon:"
 msgstr "Simgeyi göster:"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Şarkı metnini göster"
@@ -142,7 +142,7 @@ msgstr "Albüm kapağını simge olarak kullan"
 msgid "Fallback to icon if cover is not available"
 msgstr "Kapak yoksa yerine simgeyi kullan"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Albüm kapağı köşe yarıçapı:"
@@ -152,51 +152,51 @@ msgstr "Albüm kapağı köşe yarıçapı:"
 msgid "Song text customization"
 msgstr "Şarkı metni özelleştirme"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Şarkı adı konumu:"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Gizli"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "İlk satır"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "İkinci satır"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Sanatçıların konumu:"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Albüm adı konumu:"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "Tekli parçalarda albüm adını gizle:"
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -242,7 +242,7 @@ msgstr "Soldur"
 msgid "None"
 msgstr "Hiçbiri"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Metin kaydırma"
@@ -252,7 +252,7 @@ msgstr "Metin kaydırma"
 msgid "Enabled"
 msgstr "Etkin"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Hız:"
@@ -297,7 +297,7 @@ msgstr "Oynatma kontrolleri özelleştirme"
 msgid "Space between controls"
 msgstr "Kontroller arası boşluk"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Arka plan"
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Background radius:"
 msgstr "Arka plan köşe yarıçapı:"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr ""
@@ -346,67 +346,67 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Simgeyi Temizle"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "Albüm kapağını göster"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "İlerleme çubuğunu göster"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "Sol"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "Sağ"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "Şarkı metni konumu:"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "İlerleme çubuğunun üstünde"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "İlerleme çubuğunun altında"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "Ses düzeyi kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "Karıştırma kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "Oynatma kontrollerini göster"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "Döngü kontrolünü göster"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Kullanılabilir alanı oynatma kontrolleriyle doldur"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
@@ -415,89 +415,99 @@ msgstr ""
 "Etkinleştirildiğinde, oynatma kontrolleri araç takımının tüm genişliğine "
 "yayılır. Devre dışı bırakıldığında ortada gruplandırılır."
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "Minimum boyutlandırılabilir genişlik:"
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "Maksimum boyutlandırılabilir genişlik:"
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Albüm kapağı"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "Albüm yer tutucusu:"
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Seç…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Temizle"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "Yuvarlak albüm kapağı"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Şarkı metni özelleştirme"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Arka plan (yalnızca masaüstü araç takımı):"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Standart"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Saydam"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Saydam (Gölgeli içerik)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Albüm kapağını arka plan olarak kullan"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Deneysel özellik)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/uk.po
+++ b/src/translate/uk.po
@@ -7,10 +7,10 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-09 13:21+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2025-09-30 01:49+0200\n"
-"Last-Translator: Vsevolod «Damglador» Stopchanskyi <vse.stopchanskyi@gmail."
-"com>\n"
+"Last-Translator: Vsevolod «Damglador» Stopchanskyi "
+"<vse.stopchanskyi@gmail.com>\n"
 "Language-Team: \n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
@@ -33,23 +33,23 @@ msgstr "Панельний показ"
 msgid "Full View"
 msgstr "Повний показ"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr ""
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "Сфокусувати програвач"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:31
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "Цей програвач неможливо сфокусувати"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "Компонування"
@@ -71,7 +71,7 @@ msgstr ""
 "піктограмою ліворуч чи зверху та елементами керування праворуч чи унизу. "
 "Опис композиції може бути розташований за побажанням. "
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "Розташування опису композиції"
@@ -81,7 +81,7 @@ msgstr "Розташування опису композиції"
 msgid "Left (Top for vertical panel)"
 msgstr "Ліворуч (зверху для вертикальних панелей)"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "По центру"
@@ -96,7 +96,7 @@ msgstr "Праворуч (унизу для вертикальних панел�
 msgid "Show icon:"
 msgstr "Показувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "Показувати опис композиції"
@@ -142,7 +142,7 @@ msgstr "Використовувати зображення альбому"
 msgid "Fallback to icon if cover is not available"
 msgstr "Інакше, використовувати піктограму"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "Радіус зображення альбому:"
@@ -152,51 +152,51 @@ msgstr "Радіус зображення альбому:"
 msgid "Song text customization"
 msgstr "Налаштування опису композиції"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "Позиція назви композиції:"
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "Прихований"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "Перший ряд"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "Другий ряд"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "Позиція композитора:"
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "Позиція назви альбому:"
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr ""
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -242,7 +242,7 @@ msgstr "Згасання"
 msgid "None"
 msgstr "Немає"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "Прокручування тексту"
@@ -252,7 +252,7 @@ msgstr "Прокручування тексту"
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "Швидкість:"
@@ -297,7 +297,7 @@ msgstr "Елементи керування відтворення"
 msgid "Space between controls"
 msgstr "Відступ між кнопками"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "Фон"
@@ -322,7 +322,7 @@ msgstr "Необхідно також увімкнути «Використов�
 msgid "Background radius:"
 msgstr "Радіус кольорового фону:"
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr ""
@@ -344,156 +344,166 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "Очистити піктограму"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, fuzzy, kde-format
 msgid "Show album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, fuzzy, kde-format
 msgid "Song text position:"
 msgstr "Позиція назви композиції:"
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, fuzzy, kde-format
 msgid "Show volume control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, fuzzy, kde-format
 msgid "Show shuffle control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, fuzzy, kde-format
 msgid "Show playback controls"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, fuzzy, kde-format
 msgid "Show loop control"
 msgstr "Кнопка «Призупинити/Відтворити»"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, fuzzy, kde-format
 msgid "Fill available space with playback controls"
 msgstr "Заповнити доступний простір панелі"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
 "Source. Only works when 'Choose automatically' is selected."
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr ""
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:127
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "Вибрати…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "Очистити"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, fuzzy, kde-format
 msgid "Round album cover"
 msgstr "Обкладинка альбому"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "Налаштування опису композиції"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "Фон (лише для стільникового віджета)"
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "Стандартний"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "Прозорий"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "Прозорий (з тінями від вмісту)"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "Використовувати обкладинку як фон"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "(Експериментальна функція)"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr ""

--- a/src/translate/zh_CN.po
+++ b/src/translate/zh_CN.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plasmusic-toolbar\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-02 07:43+0000\n"
+"POT-Creation-Date: 2026-08-13 10:30+0600\n"
 "PO-Revision-Date: 2026-08-02 07:43+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -32,23 +32,23 @@ msgstr "面板视图"
 msgid "Full View"
 msgstr "完整视图"
 
-#: src/contents/ui/Full.qml:162
+#: src/contents/ui/Full.qml:172
 #, kde-format
 msgctxt "@action:button"
 msgid "Choose player automatically"
 msgstr "自动选择播放器"
 
-#: src/contents/ui/Full.qml:192
+#: src/contents/ui/Full.qml:206
 #, kde-format
 msgid "Bring player to the front"
 msgstr "将播放器置顶"
 
-#: src/contents/ui/Full.qml:192 src/contents/ui/main.qml:32
+#: src/contents/ui/Full.qml:206 src/contents/ui/main.qml:31
 #, kde-format
 msgid "This player can't be raised"
 msgstr "无法置顶此播放器"
 
-#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:46
+#: src/contents/ui/config/Compact.qml:50 src/contents/ui/config/Full.qml:48
 #, kde-format
 msgid "Layout"
 msgstr "布局"
@@ -66,11 +66,10 @@ msgid ""
 "playback controls are aligned to the right (or bottom); The song text can be "
 "positioned based on user preference."
 msgstr ""
-"该小部件会填满水平面板的全部可用宽度（或垂直面板的全部可用高度）；图标"
-"靠左（或靠上）对齐，播放控制靠右（或靠下）对齐；歌曲文本可根据用户偏好调"
-"整位置。"
+"该小部件会填满水平面板的全部可用宽度（或垂直面板的全部可用高度）；图标靠左"
+"（或靠上）对齐，播放控制靠右（或靠下）对齐；歌曲文本可根据用户偏好调整位置。"
 
-#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:65
+#: src/contents/ui/config/Compact.qml:71 src/contents/ui/config/Full.qml:67
 #, kde-format
 msgid "Song text alignment:"
 msgstr "歌曲文本对齐："
@@ -80,7 +79,7 @@ msgstr "歌曲文本对齐："
 msgid "Left (Top for vertical panel)"
 msgstr "左（垂直面板中为顶部）"
 
-#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:78
+#: src/contents/ui/config/Compact.qml:83 src/contents/ui/config/Full.qml:80
 #, kde-format
 msgid "Center"
 msgstr "居中"
@@ -95,7 +94,7 @@ msgstr "右（垂直面板中为底部）"
 msgid "Show icon:"
 msgstr "显示图标："
 
-#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:103
+#: src/contents/ui/config/Compact.qml:111 src/contents/ui/config/Full.qml:105
 #, kde-format
 msgid "Show song text"
 msgstr "显示歌曲文本"
@@ -141,7 +140,7 @@ msgstr "使用专辑封面作为图标"
 msgid "Fallback to icon if cover is not available"
 msgstr "无封面时回退为图标"
 
-#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:245
+#: src/contents/ui/config/Compact.qml:166 src/contents/ui/config/Full.qml:263
 #, kde-format
 msgid "Album cover radius:"
 msgstr "专辑封面圆角："
@@ -151,51 +150,51 @@ msgstr "专辑封面圆角："
 msgid "Song text customization"
 msgstr "歌曲文本自定义"
 
-#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:261
+#: src/contents/ui/config/Compact.qml:182 src/contents/ui/config/Full.qml:279
 #, kde-format
 msgid "Song title position:"
 msgstr "歌曲标题位置："
 
 #: src/contents/ui/config/Compact.qml:183
 #: src/contents/ui/config/Compact.qml:230
-#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:262
-#: src/contents/ui/config/Full.qml:309 src/contents/ui/config/Full.qml:354
+#: src/contents/ui/config/Compact.qml:275 src/contents/ui/config/Full.qml:280
+#: src/contents/ui/config/Full.qml:327 src/contents/ui/config/Full.qml:372
 #, kde-format
 msgid "Hidden"
 msgstr "隐藏"
 
 #: src/contents/ui/config/Compact.qml:194
 #: src/contents/ui/config/Compact.qml:241
-#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:273
-#: src/contents/ui/config/Full.qml:320 src/contents/ui/config/Full.qml:365
+#: src/contents/ui/config/Compact.qml:286 src/contents/ui/config/Full.qml:291
+#: src/contents/ui/config/Full.qml:338 src/contents/ui/config/Full.qml:383
 #, kde-format
 msgid "First line"
 msgstr "第一行"
 
 #: src/contents/ui/config/Compact.qml:205
 #: src/contents/ui/config/Compact.qml:252
-#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:284
-#: src/contents/ui/config/Full.qml:331 src/contents/ui/config/Full.qml:376
+#: src/contents/ui/config/Compact.qml:297 src/contents/ui/config/Full.qml:302
+#: src/contents/ui/config/Full.qml:349 src/contents/ui/config/Full.qml:394
 #, kde-format
 msgid "Second line"
 msgstr "第二行"
 
-#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:308
+#: src/contents/ui/config/Compact.qml:229 src/contents/ui/config/Full.qml:326
 #, kde-format
 msgid "Artists position:"
 msgstr "艺术家位置："
 
-#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:353
+#: src/contents/ui/config/Compact.qml:274 src/contents/ui/config/Full.qml:371
 #, kde-format
 msgid "Album title position:"
 msgstr "专辑标题位置："
 
-#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:387
+#: src/contents/ui/config/Compact.qml:308 src/contents/ui/config/Full.qml:405
 #, kde-format
 msgid "Hide album name for singles:"
 msgstr "单曲时隐藏专辑名："
 
-#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:393
+#: src/contents/ui/config/Compact.qml:314 src/contents/ui/config/Full.qml:411
 #, kde-format
 msgid ""
 "If the album name and the track title match, the album name will be hidden."
@@ -241,7 +240,7 @@ msgstr "淡出"
 msgid "None"
 msgstr "无"
 
-#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:400
+#: src/contents/ui/config/Compact.qml:396 src/contents/ui/config/Full.qml:418
 #, kde-format
 msgid "Text scrolling"
 msgstr "文本滚动"
@@ -251,7 +250,7 @@ msgstr "文本滚动"
 msgid "Enabled"
 msgstr "启用"
 
-#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:409
+#: src/contents/ui/config/Compact.qml:410 src/contents/ui/config/Full.qml:427
 #, kde-format
 msgid "Speed:"
 msgstr "速度："
@@ -296,7 +295,7 @@ msgstr "播放控制自定义"
 msgid "Space between controls"
 msgstr "控制按钮间距"
 
-#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:414
+#: src/contents/ui/config/Compact.qml:490 src/contents/ui/config/Full.qml:432
 #, kde-format
 msgid "Background"
 msgstr "背景"
@@ -321,7 +320,7 @@ msgstr "背景功能需要勾选“使用专辑封面作为图标”。"
 msgid "Background radius:"
 msgstr "背景圆角："
 
-#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:476
+#: src/contents/ui/config/Compact.qml:523 src/contents/ui/config/Full.qml:494
 #, kde-format
 msgid "Hover tooltip"
 msgstr "悬停工具提示"
@@ -343,90 +342,99 @@ msgctxt "@item:inmenu Reset icon to default"
 msgid "Clear Icon"
 msgstr "清除图标"
 
-#: src/contents/ui/config/Full.qml:51
+#: src/contents/ui/config/Full.qml:53
 #, kde-format
 msgid "Show album cover"
 msgstr "显示专辑封面"
 
-#: src/contents/ui/config/Full.qml:56
+#: src/contents/ui/config/Full.qml:58
 #, kde-format
 msgid "Show progress bar"
 msgstr "显示进度条"
 
-#: src/contents/ui/config/Full.qml:66
+#: src/contents/ui/config/Full.qml:68
 #, kde-format
 msgid "Left"
 msgstr "左"
 
-#: src/contents/ui/config/Full.qml:90
+#: src/contents/ui/config/Full.qml:92
 #, kde-format
 msgid "Right"
 msgstr "右"
 
-#: src/contents/ui/config/Full.qml:112
+#: src/contents/ui/config/Full.qml:114
 #, kde-format
 msgid "Song text position:"
 msgstr "歌曲文本位置："
 
-#: src/contents/ui/config/Full.qml:113
+#: src/contents/ui/config/Full.qml:115
 #, kde-format
 msgid "Above progress bar"
 msgstr "进度条上方"
 
-#: src/contents/ui/config/Full.qml:125
+#: src/contents/ui/config/Full.qml:127
 #, kde-format
 msgid "Under progress bar"
 msgstr "进度条下方"
 
-#: src/contents/ui/config/Full.qml:138
+#: src/contents/ui/config/Full.qml:140
 #, kde-format
 msgid "Show volume control"
 msgstr "显示音量控制"
 
-#: src/contents/ui/config/Full.qml:143
+#: src/contents/ui/config/Full.qml:145
 #, kde-format
 msgid "Show shuffle control"
 msgstr "显示随机播放控制"
 
-#: src/contents/ui/config/Full.qml:148
+#: src/contents/ui/config/Full.qml:150
 #, kde-format
 msgid "Show playback controls"
 msgstr "显示播放控制"
 
-#: src/contents/ui/config/Full.qml:153
+#: src/contents/ui/config/Full.qml:155
 #, kde-format
 msgid "Show loop control"
 msgstr "显示循环控制"
 
-#: src/contents/ui/config/Full.qml:157
+#: src/contents/ui/config/Full.qml:159
 #, kde-format
 msgid "Fill available space with playback controls"
 msgstr "用播放控制填充可用空间"
 
-#: src/contents/ui/config/Full.qml:163
+#: src/contents/ui/config/Full.qml:165
 #, kde-format
 msgid ""
 "When enabled, playback controls are spread across the full width of the "
 "widget. When disabled, they are grouped together in the center."
-msgstr ""
-"启用后，播放控制将分布在小部件的整个宽度上；禁用时则集中在中间。"
+msgstr "启用后，播放控制将分布在小部件的整个宽度上；禁用时则集中在中间。"
 
-#: src/contents/ui/config/Full.qml:170
+#: src/contents/ui/config/Full.qml:172
 #, kde-format
 msgid "Minimum resizable width:"
 msgstr "最小可调整宽度："
 
-#: src/contents/ui/config/Full.qml:178
+#: src/contents/ui/config/Full.qml:180
 #, kde-format
 msgid "Maximum resizable width:"
 msgstr "最大可调整宽度："
 
-#: src/contents/ui/config/Full.qml:185
+#: src/contents/ui/config/Full.qml:188
+#, kde-format
+msgid "Minimum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:196
+#, kde-format
+msgid "Maximum resizable height:"
+msgstr ""
+
+#: src/contents/ui/config/Full.qml:203
 #, kde-format
 msgid "Show media player selector"
 msgstr "显示媒体播放器选择器"
 
-#: src/contents/ui/config/Full.qml:191
+#: src/contents/ui/config/Full.qml:209
 #, kde-format
 msgid ""
 "Disabled when a preferred player is selected under General > Playback "
@@ -434,67 +442,67 @@ msgid ""
 msgstr ""
 "在“常规 > 播放源”中选择了首选播放器时禁用。仅在选择了“自动选择”时有效。"
 
-#: src/contents/ui/config/Full.qml:198
+#: src/contents/ui/config/Full.qml:216
 #, kde-format
 msgid "Album cover"
 msgstr "专辑封面"
 
-#: src/contents/ui/config/Full.qml:202
+#: src/contents/ui/config/Full.qml:220
 #, kde-format
 msgid "Album placeholder:"
 msgstr "专辑占位图："
 
-#: src/contents/ui/config/Full.qml:205 src/contents/ui/config/General.qml:132
+#: src/contents/ui/config/Full.qml:223 src/contents/ui/config/General.qml:127
 #, kde-format
 msgid "Choose…"
 msgstr "选择…"
 
-#: src/contents/ui/config/Full.qml:213
+#: src/contents/ui/config/Full.qml:231
 #, kde-format
 msgid "Clear"
 msgstr "清除"
 
-#: src/contents/ui/config/Full.qml:234
+#: src/contents/ui/config/Full.qml:252
 #, kde-format
 msgid "Round album cover"
 msgstr "圆形专辑封面"
 
-#: src/contents/ui/config/Full.qml:250
+#: src/contents/ui/config/Full.qml:268
 #, kde-format
 msgid "Song Text Customization"
 msgstr "歌曲文本自定义"
 
-#: src/contents/ui/config/Full.qml:423
+#: src/contents/ui/config/Full.qml:441
 #, kde-format
 msgid "Background (desktop widget only):"
 msgstr "背景（仅桌面小部件）："
 
-#: src/contents/ui/config/Full.qml:425
+#: src/contents/ui/config/Full.qml:443
 #, kde-format
 msgid "Standard"
 msgstr "标准"
 
-#: src/contents/ui/config/Full.qml:441
+#: src/contents/ui/config/Full.qml:459
 #, kde-format
 msgid "Transparent"
 msgstr "透明"
 
-#: src/contents/ui/config/Full.qml:452
+#: src/contents/ui/config/Full.qml:470
 #, kde-format
 msgid "Transparent (Shadow content)"
 msgstr "透明（阴影内容）"
 
-#: src/contents/ui/config/Full.qml:469
+#: src/contents/ui/config/Full.qml:487
 #, kde-format
 msgid "Use album cover as background"
 msgstr "使用专辑封面作为背景"
 
-#: src/contents/ui/config/Full.qml:471
+#: src/contents/ui/config/Full.qml:489
 #, kde-format
 msgid "(Experimental feature)"
 msgstr "（实验性功能）"
 
-#: src/contents/ui/config/Full.qml:481
+#: src/contents/ui/config/Full.qml:499
 #, kde-format
 msgid "Hide album art tooltip"
 msgstr "隐藏专辑封面工具提示"
@@ -521,8 +529,8 @@ msgid ""
 "If two or more players are playing at the same time, the widget will choose "
 "the one that started playing first."
 msgstr ""
-"将根据当前正在播放的歌曲自动选择播放器。如果两个或多个播放器同时播放，"
-"小部件将选择最先开始播放的那个。"
+"将根据当前正在播放的歌曲自动选择播放器。如果两个或多个播放器同时播放，小部件"
+"将选择最先开始播放的那个。"
 
 #: src/contents/ui/config/General.qml:54
 #, kde-format
@@ -539,7 +547,7 @@ msgstr "未选择"
 msgid "%1 players selected"
 msgstr "已选择 %1 个播放器"
 
-#: src/contents/ui/config/General.qml:113
+#: src/contents/ui/config/General.qml:108
 #, kde-format
 msgid ""
 "Always display information from the selected player, if it's not running the "
@@ -547,88 +555,88 @@ msgid ""
 "players that are currently running, if you can't find the one you want, open "
 "the player application and reload the list with reload button."
 msgstr ""
-"始终显示所选播放器的信息；如果它未运行，小部件将被隐藏。你可以在下拉列表"
-"中选择当前正在运行的所有播放器；如果找不到想要的播放器，请打开播放器应"
-"用，然后点击重新加载按钮刷新列表。"
+"始终显示所选播放器的信息；如果它未运行，小部件将被隐藏。你可以在下拉列表中选"
+"择当前正在运行的所有播放器；如果找不到想要的播放器，请打开播放器应用，然后点"
+"击重新加载按钮刷新列表。"
 
-#: src/contents/ui/config/General.qml:121
+#: src/contents/ui/config/General.qml:116
 #, kde-format
 msgid "Font customization"
 msgstr "字体自定义"
 
-#: src/contents/ui/config/General.qml:125
+#: src/contents/ui/config/General.qml:120
 #, kde-format
 msgid "Custom font:"
 msgstr "自定义字体："
 
-#: src/contents/ui/config/General.qml:143
+#: src/contents/ui/config/General.qml:138
 #, kde-format
 msgid "%1pt %2"
 msgstr "%1pt %2"
 
-#: src/contents/ui/config/General.qml:150
+#: src/contents/ui/config/General.qml:145
 #, kde-format
 msgid "No media found behavior"
 msgstr "未找到媒体时的行为"
 
-#: src/contents/ui/config/General.qml:155
+#: src/contents/ui/config/General.qml:150
 #, kde-format
 msgid "Show widget when no media found"
 msgstr "未找到媒体时显示小部件"
 
-#: src/contents/ui/config/General.qml:160
+#: src/contents/ui/config/General.qml:155
 #, kde-format
 msgid "Text displayed when no media found:"
 msgstr "未找到媒体时显示的文本："
 
-#: src/contents/ui/config/General.qml:166
+#: src/contents/ui/config/General.qml:161
 #, kde-format
 msgid "Controls behaviour"
 msgstr "控制行为"
 
-#: src/contents/ui/config/General.qml:171
+#: src/contents/ui/config/General.qml:166
 #, kde-format
 msgid "Volume step:"
 msgstr "音量步进："
 
-#: src/contents/ui/config/General.qml:181
+#: src/contents/ui/config/General.qml:176
 #, kde-format
 msgid "Choose a Font"
 msgstr "选择字体"
 
-#: src/contents/ui/main.qml:25
+#: src/contents/ui/main.qml:24
 #, kde-format
 msgid "No media playing"
 msgstr "没有正在播放的媒体"
 
-#: src/contents/ui/main.qml:27
+#: src/contents/ui/main.qml:26
 #, kde-format
 msgctxt "%1 is the media artist/author and %2 is the player name"
 msgid "by %1 (%2)"
 msgstr "来自 %1（%2）"
 
-#: src/contents/ui/main.qml:28
+#: src/contents/ui/main.qml:27
 #, kde-format
 msgctxt "%1 is the player name"
 msgid "%1"
 msgstr "%1"
 
-#: src/contents/ui/main.qml:30
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to pause"
 msgstr "中键单击暂停"
 
-#: src/contents/ui/main.qml:30
+#: src/contents/ui/main.qml:29
 #, kde-format
 msgid "Middle-click to play"
 msgstr "中键单击播放"
 
-#: src/contents/ui/main.qml:31
+#: src/contents/ui/main.qml:30
 #, kde-format
 msgid "Scroll to adjust volume"
 msgstr "滚动调节音量"
 
-#: src/contents/ui/main.qml:32
+#: src/contents/ui/main.qml:31
 #, kde-format
 msgid "Ctrl+Click to bring player to the front"
 msgstr "Ctrl+单击将播放器置顶"


### PR DESCRIPTION
Make the full view popup height resizable independently of its width, decoupling it from the album thumbnail aspect ratio so resizing doesn't look aspect-ratio locked. Adds min/max height config options.