### PR TITLE
feat: Implement Copy Track Function

### DIFF
--- a/src/contents/ui/Full.qml
+++ b/src/contents/ui/Full.qml
@@ -278,6 +278,41 @@ Item {
             albumPosition: plasmoid.configuration.fullAlbumPosition
             hideAlbumForSingles: plasmoid.configuration.fullHideAlbumForSingles
             scrollingEnabled: widget.expanded
+
+            // Copy Track Info
+            PlasmaComponents3.ToolTip {
+                id: copyTrackToolTip
+                text: copyTrackMouseArea.pressed || copyTimer.running ? i18n("Copied!") : i18n("Click to copy the Track info!")
+                visible: copyTrackMouseArea.containsMouse
+            }
+
+            MouseArea {
+                id: copyTrackMouseArea
+                anchors.fill: parent
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    copyHelper.text = player.title + " | " + player.artists
+                    copyHelper.selectAll()
+                    copyHelper.copy()
+                    copyHelper.deselect()
+                    copyTimer.restart()
+                }
+                hoverEnabled: true
+            }
+
+            Timer {
+                id: copyTimer
+                interval: 1000
+                repeat: false
+                onTriggered: copyTrackMouseArea.pressed
+            }
+
+            // Temporary Clipboard for Track Info
+            TextEdit {
+                id: copyHelper
+                visible: false
+                readOnly: true
+            }
         }
 
         VolumeBar {


### PR DESCRIPTION
This PR added the idea of copy the track information in the `Track | Artist` Format #321.

The Feature is bydefault turned on. So, the option to toggle the feature on or off isn't pushed to the PR yet, but already implmented in my copy. As, I think this feature doesn't disturb the functionality of the user who doesn't want to use it.

But If the Maintainer says so then I would commit the Toggelable Option.

<img width="400" height="195" alt="copyTrackInfo" src="https://github.com/user-attachments/assets/f8db95b1-21e8-4871-8e54-8902f628b499" />
